### PR TITLE
Negrep: fix standard input redirection handling

### DIFF
--- a/Deployment/smoke_test_osx.sh
+++ b/Deployment/smoke_test_osx.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 tar -xf Publish/negrep-osx-x64.tar.gz
 cd negrep
 echo '\n./examples/patterns.np:\n'

--- a/Deployment/smoke_test_windows.ps1
+++ b/Deployment/smoke_test_windows.ps1
@@ -25,8 +25,8 @@ function Test-WindowsZipPackage {
     cat ./NOTICE
     cat ./LICENSE.txt
     cat ./THIRD-PARTY-NOTICES.txt
-    ./negrep.exe -f ./examples/patterns.np ./examples/example.txt
-    ./negrep.exe --version
+    Invoke-NativeCommand ./negrep.exe -f ./examples/patterns.np ./examples/example.txt
+    Invoke-NativeCommand ./negrep.exe --version
 }
 
 function Invoke-NativeCommand() {

--- a/Source/Negrep.Tests/NegrepPositiveTests.cs
+++ b/Source/Negrep.Tests/NegrepPositiveTests.cs
@@ -199,6 +199,17 @@ namespace Nezaboodka.Nevod.Negrep.Tests
         }
 
         [Test]
+        public async Task SearchPatternsFromFileAndOneFileWhenBothRedirected()
+        {
+            string[] args = { "-f", "patterns.np", "file1" };
+            string expected = @"
+                file1:Phone:IS ANDROID OR IPHONE THE BETTER SMARTPHONE?
+                file1:FirstWord:IS ANDROID OR IPHONE THE BETTER SMARTPHONE?
+            ";
+            await NegrepTestsRunner.CompareDataInStdoutWhenBothRedirected(args, expected);
+        }
+
+        [Test]
         public async Task SearchPatternsFromFileWith_h_OptionAndOneFileWhenOutputRedirected()
         {
             string[] args = { "-f", "patterns.np", "-h", "file1" };

--- a/Source/Negrep/NegrepConfig.cs
+++ b/Source/Negrep/NegrepConfig.cs
@@ -58,7 +58,6 @@ namespace Nezaboodka.Nevod.Negrep
         {
             _console = console;
             FilePaths = new List<string>();
-            IsSourceTextFromStdin = _console.IsInputRedirected;
             IsStreamModeEnabled = isStreamModeEnabled;
 
             var clFormatType = GetCommandLineFormatType(args);
@@ -122,6 +121,8 @@ namespace Nezaboodka.Nevod.Negrep
                     break;
             }
 
+            IsSourceTextFromStdin = _console.IsInputRedirected && !negrepArgs.FilesProvided;
+
             PrefixingMode prefixingMode;
             if (status != NegrepConfigStatus.UsageRequest)
             {
@@ -157,7 +158,7 @@ namespace Nezaboodka.Nevod.Negrep
                 if (_console.IsOutputRedirected)
                     ResultTagsPrinter = new PacketModePrinter(_console, prefixingMode, printMode);
                 else
-                    ResultTagsPrinter = new InteractiveModePrinter(_console, prefixingMode, printMode);
+                    ResultTagsPrinter = new InteractiveModePrinter(_console, prefixingMode, printMode, IsSourceTextFromStdin);
             }
 
             return status;

--- a/Source/Negrep/ResultTagsPrinters/InteractiveModePrinter.cs
+++ b/Source/Negrep/ResultTagsPrinters/InteractiveModePrinter.cs
@@ -13,12 +13,16 @@ namespace Nezaboodka.Nevod.Negrep.ResultTagsPrinters
 {
     internal class InteractiveModePrinter : ResultTagsPrinter
     {
+        private readonly bool _isSourceTextFromStdin;
+
         private readonly ConsoleColor FilenameColor = ConsoleColor.DarkGray;
         private readonly ConsoleColor TagnameColor = ConsoleColor.Green;
         private readonly ConsoleColor MatchColor = ConsoleColor.Red;
 
-        public InteractiveModePrinter(IConsole console, PrefixingMode prefixingMode, PrintMode printMode)
+        public InteractiveModePrinter(IConsole console, PrefixingMode prefixingMode, PrintMode printMode,
+            bool isSourceTextFromStdin)
         {
+            _isSourceTextFromStdin = isSourceTextFromStdin;
             _console = console;
             _prefixingMode = prefixingMode;
             _printMode = printMode;
@@ -26,7 +30,7 @@ namespace Nezaboodka.Nevod.Negrep.ResultTagsPrinters
 
         public override void Print(SourceTextInfo sourceTextInfo, IEnumerable<ResultTag> resultTags)
         {
-            if (!_console.IsInputRedirected &&
+            if (!_isSourceTextFromStdin &&
                 (_prefixingMode & PrefixingMode.PrefixWithFilename) == PrefixingMode.PrefixWithFilename)
             {
                 _console.WriteLine($"{sourceTextInfo.Path}:", FilenameColor);


### PR DESCRIPTION
- When standard input is redirected and file is provided via command line argument, use file to search in (not standard input).
- Update macOS test script to make sure negrep produces results from search.
- Update Windows test script to make sure negrep produces results from search.