### PR TITLE
Add source text information to syntax objects and make PatternLinker class public

### DIFF
--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -514,43 +514,43 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
     Pattern8(X) = [1+ X: Symbol + X];
     Pattern9(X, ~Y) = {X: Punct + X, Y: Symbol + Y};
     Pattern10 = 'Hello' + WordBreak + 'World' + WordBreak + '!';
-}";
+}".Replace("\r\n", "\n"); // Use \n as line feeds to make positions platform-independent
             var parser = new SyntaxParser();
             PackageSyntax package = parser.ParsePackageText(patterns);
-            TestSourceTextInformation(package, 0, 725);
+            TestSourceTextInformation(package, 0, 706);
             void Pattern1()
             {
                 var pattern = (PatternSyntax) package.Patterns[0];
-                TestSourceTextInformation(pattern, 24, 137);
+                TestSourceTextInformation(pattern, 23, 133);
                 var sequence = (SequenceSyntax) pattern.Body;
-                TestSourceTextInformation(sequence, 35, 40);
-                TestSourceTextInformation(sequence.Elements[0], 35, 36);
-                TestSourceTextInformation(sequence.Elements[1], 39, 40);
+                TestSourceTextInformation(sequence, 34, 39);
+                TestSourceTextInformation(sequence.Elements[0], 34, 35);
+                TestSourceTextInformation(sequence.Elements[1], 38, 39);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 59, 86);
+                    TestSourceTextInformation(patternA, 57, 84);
                     var sequence = (SequenceSyntax) patternA.Body;
-                    TestSourceTextInformation(sequence, 63, 85);
-                    TestSourceTextInformation(sequence.Elements[0], 63, 67);
+                    TestSourceTextInformation(sequence, 61, 83);
+                    TestSourceTextInformation(sequence.Elements[0], 61, 65);
                     var variation = (VariationSyntax) sequence.Elements[1];
-                    TestSourceTextInformation(variation, 70, 85);
-                    TestSourceTextInformation(variation.Elements[0], 71, 76);
+                    TestSourceTextInformation(variation, 68, 83);
+                    TestSourceTextInformation(variation.Elements[0], 69, 74);
                     var exception = (ExceptionSyntax) variation.Elements[1];
-                    TestSourceTextInformation(exception, 78, 84);
-                    TestSourceTextInformation(exception.Body, 79, 84);
+                    TestSourceTextInformation(exception, 76, 82);
+                    TestSourceTextInformation(exception.Body, 77, 82);
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 96, 129);
+                    TestSourceTextInformation(patternB, 93, 126);
                     var span = (SpanSyntax) patternB.Body;
-                    TestSourceTextInformation(span, 100, 128);
+                    TestSourceTextInformation(span, 97, 125);
                     var repetition = (RepetitionSyntax) span.Elements[0];
-                    TestSourceTextInformation(repetition, 101, 127);
+                    TestSourceTextInformation(repetition, 98, 124);
                     var conjunction = (ConjunctionSyntax) repetition.Body;
-                    TestSourceTextInformation(conjunction.Elements[0], 104, 112);
-                    TestSourceTextInformation(conjunction.Elements[1], 115, 127);
+                    TestSourceTextInformation(conjunction.Elements[0], 101, 109);
+                    TestSourceTextInformation(conjunction.Elements[1], 112, 124);
                 }
                 PatternA();
                 PatternB();
@@ -558,27 +558,27 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern2()
             {
                 var pattern2 = (PatternSyntax) package.Patterns[1];
-                TestSourceTextInformation(pattern2, 149, 282);
+                TestSourceTextInformation(pattern2, 143, 273);
                 var wordSequence = (WordSequenceSyntax) pattern2.Body;
-                TestSourceTextInformation(wordSequence.Elements[0], 160, 161);
-                TestSourceTextInformation(wordSequence.Elements[1], 164, 165);
+                TestSourceTextInformation(wordSequence.Elements[0], 154, 155);
+                TestSourceTextInformation(wordSequence.Elements[1], 158, 159);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern2.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 184,  218);
+                    TestSourceTextInformation(patternA, 177,  211);
                     var outside = (OutsideSyntax) patternA.Body;
-                    TestSourceTextInformation(outside, 188, 217);
-                    TestSourceTextInformation(outside.Body, 188, 197);
-                    TestSourceTextInformation(outside.Exception, 207, 217);
+                    TestSourceTextInformation(outside, 181, 210);
+                    TestSourceTextInformation(outside.Body, 181, 190);
+                    TestSourceTextInformation(outside.Exception, 200, 210);
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern2.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 228, 274);
+                    TestSourceTextInformation(patternB, 220, 266);
                     var having = (HavingSyntax)patternB.Body;
-                    TestSourceTextInformation(having, 232, 273);
-                    TestSourceTextInformation(having.Outer, 232, 242);
-                    TestSourceTextInformation(having.Inner, 251, 273);
+                    TestSourceTextInformation(having, 224, 265);
+                    TestSourceTextInformation(having.Outer, 224, 234);
+                    TestSourceTextInformation(having.Inner, 243, 265);
                 }
                 PatternA();
                 PatternB();
@@ -586,109 +586,109 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern3()
             {
                 var pattern3 = (PatternSyntax) package.Patterns[2];
-                TestSourceTextInformation(pattern3, 290, 328);
+                TestSourceTextInformation(pattern3, 279, 317);
                 var sequence = (SequenceSyntax) pattern3.Body;
-                TestSourceTextInformation(sequence, 301, 327);
-                TestSourceTextInformation(sequence.Elements[0], 301, 313);
+                TestSourceTextInformation(sequence, 290, 316);
+                TestSourceTextInformation(sequence.Elements[0], 290, 302);
                 var optionality = (OptionalitySyntax) sequence.Elements[1];
-                TestSourceTextInformation(optionality, 316, 327);
-                TestSourceTextInformation(optionality.Body, 318, 327);
+                TestSourceTextInformation(optionality, 305, 316);
+                TestSourceTextInformation(optionality.Body, 307, 316);
             }
             void Pattern4()
             {
                 var pattern4 = (PatternSyntax) package.Patterns[3];
-                TestSourceTextInformation(pattern4, 334, 409);
+                TestSourceTextInformation(pattern4, 322, 397);
                 var wordSpan = (WordSpanSyntax) pattern4.Body;
-                TestSourceTextInformation(wordSpan, 362, 408);
-                TestSourceTextInformation(wordSpan.Left, 362, 368);
-                TestSourceTextInformation(wordSpan.Right, 381, 408);
+                TestSourceTextInformation(wordSpan, 350, 396);
+                TestSourceTextInformation(wordSpan.Left, 350, 356);
+                TestSourceTextInformation(wordSpan.Right, 369, 396);
             }
             void Pattern5()
             {
                 var pattern5 = (PatternSyntax) package.Patterns[4];
-                TestSourceTextInformation(pattern5, 415, 463);
+                TestSourceTextInformation(pattern5, 402, 450);
                 var inside = (InsideSyntax) pattern5.Body;
-                TestSourceTextInformation(inside.Inner, 427, 434);
-                TestSourceTextInformation(inside.Outer, 444, 461);
+                TestSourceTextInformation(inside.Inner, 414, 421);
+                TestSourceTextInformation(inside.Outer, 431, 448);
                 var sequence = (SequenceSyntax) inside.Outer;
-                TestSourceTextInformation(sequence.Elements[0], 444, 451);
-                TestSourceTextInformation(sequence.Elements[1], 454, 461);   
+                TestSourceTextInformation(sequence.Elements[0], 431, 438);
+                TestSourceTextInformation(sequence.Elements[1], 441, 448);   
             }
             void Pattern6()
             {
                 var pattern6 = (PatternSyntax) package.Patterns[5];
-                TestSourceTextInformation(pattern6, 469, 519);
-                TestSourceTextInformation(pattern6.Fields[0], 478, 479);
-                TestSourceTextInformation(pattern6.Fields[1], 481, 482);
+                TestSourceTextInformation(pattern6, 455, 505);
+                TestSourceTextInformation(pattern6.Fields[0], 464, 465);
+                TestSourceTextInformation(pattern6.Fields[1], 467, 468);
                 var anySpan = (AnySpanSyntax) pattern6.Body;
-                TestSourceTextInformation(anySpan, 486, 518);
+                TestSourceTextInformation(anySpan, 472, 504);
                 var xExtraction = (ExtractionSyntax) anySpan.Left;
-                TestSourceTextInformation(xExtraction, 486, 501);
-                TestSourceTextInformation(xExtraction.Body, 489, 501);
+                TestSourceTextInformation(xExtraction, 472, 487);
+                TestSourceTextInformation(xExtraction.Body, 475, 487);
                 var yExtraction = (ExtractionSyntax) anySpan.Right;
-                TestSourceTextInformation(yExtraction, 506, 518);
-                TestSourceTextInformation(yExtraction.Body, 509, 518);
+                TestSourceTextInformation(yExtraction, 492, 504);
+                TestSourceTextInformation(yExtraction.Body, 495, 504);
             }
             void Pattern7()
             {
                 var pattern7 = (PatternSyntax) package.Patterns[6];
-                TestSourceTextInformation(pattern7, 525, 563);
-                TestSourceTextInformation(pattern7.Fields[0], 534, 535);
-                TestSourceTextInformation(pattern7.Fields[1], 537, 538);
+                TestSourceTextInformation(pattern7, 510, 548);
+                TestSourceTextInformation(pattern7.Fields[0], 519, 520);
+                TestSourceTextInformation(pattern7.Fields[1], 522, 523);
                 var patternReference = (PatternReferenceSyntax) pattern7.Body;
-                TestSourceTextInformation(patternReference, 542, 562);
-                TestSourceTextInformation(patternReference.ExtractionFromFields[0], 551, 555);
-                TestSourceTextInformation(patternReference.ExtractionFromFields[1], 557, 561);
+                TestSourceTextInformation(patternReference, 527, 547);
+                TestSourceTextInformation(patternReference.ExtractionFromFields[0], 536, 540);
+                TestSourceTextInformation(patternReference.ExtractionFromFields[1], 542, 546);
             }
             void Pattern8()
             {
                 var pattern8 = (PatternSyntax) package.Patterns[7];
-                TestSourceTextInformation(pattern8, 569, 602);
-                TestSourceTextInformation(pattern8.Fields[0], 578, 579);
+                TestSourceTextInformation(pattern8, 553, 586);
+                TestSourceTextInformation(pattern8.Fields[0], 562, 563);
                 var span = (SpanSyntax) pattern8.Body;
-                TestSourceTextInformation(span, 583, 601);
+                TestSourceTextInformation(span, 567, 585);
                 var repetition = (RepetitionSyntax) span.Elements[0];
-                TestSourceTextInformation(repetition, 584, 600);
+                TestSourceTextInformation(repetition, 568, 584);
                 var sequence = (SequenceSyntax) repetition.Body;
-                TestSourceTextInformation(sequence, 587, 600);
+                TestSourceTextInformation(sequence, 571, 584);
                 var extraction = (ExtractionSyntax) sequence.Elements[0];
-                TestSourceTextInformation(extraction, 587, 596);
-                TestSourceTextInformation(extraction.Body, 590, 596);
+                TestSourceTextInformation(extraction, 571, 580);
+                TestSourceTextInformation(extraction.Body, 574, 580);
                 Assert.AreEqual("X", extraction.FieldName);
-                TestSourceTextInformation(sequence.Elements[1], 599, 600);
+                TestSourceTextInformation(sequence.Elements[1], 583, 584);
             }
             void Pattern9()
             {
                 var pattern9 = (PatternSyntax) package.Patterns[8];
-                TestSourceTextInformation(pattern9, 608, 656);
-                TestSourceTextInformation(pattern9.Fields[0], 617, 618);
-                TestSourceTextInformation(pattern9.Fields[1], 620, 622);
+                TestSourceTextInformation(pattern9, 591, 639);
+                TestSourceTextInformation(pattern9.Fields[0], 600, 601);
+                TestSourceTextInformation(pattern9.Fields[1], 603, 605);
                 var variation = (VariationSyntax) pattern9.Body;
-                TestSourceTextInformation(variation, 626, 655);
+                TestSourceTextInformation(variation, 609, 638);
                 var sequence1 = (SequenceSyntax) variation.Elements[0];
-                TestSourceTextInformation(sequence1, 627, 639);
+                TestSourceTextInformation(sequence1, 610, 622);
                 var extractionX = (ExtractionSyntax) sequence1.Elements[0];
-                TestSourceTextInformation(extractionX, 627, 635);
-                TestSourceTextInformation(extractionX.Body, 630, 635);
-                TestSourceTextInformation(sequence1.Elements[1], 638, 639);
+                TestSourceTextInformation(extractionX, 610, 618);
+                TestSourceTextInformation(extractionX.Body, 613, 618);
+                TestSourceTextInformation(sequence1.Elements[1], 621, 622);
                 var sequence2 = (SequenceSyntax) variation.Elements[1];
-                TestSourceTextInformation(sequence2, 641, 654);
+                TestSourceTextInformation(sequence2, 624, 637);
                 var extractionY = (ExtractionSyntax) sequence2.Elements[0];
-                TestSourceTextInformation(extractionY, 641, 650);
-                TestSourceTextInformation(extractionY.Body, 644, 650);
-                TestSourceTextInformation(sequence2.Elements[1], 653, 654);
+                TestSourceTextInformation(extractionY, 624, 633);
+                TestSourceTextInformation(extractionY.Body, 627, 633);
+                TestSourceTextInformation(sequence2.Elements[1], 636, 637);
             }
             void Pattern10()
             {
                 var pattern10 = (PatternSyntax) package.Patterns[9];
-                TestSourceTextInformation(pattern10, 662, 722);
+                TestSourceTextInformation(pattern10, 644, 704);
                 var sequence = (SequenceSyntax) pattern10.Body;
-                TestSourceTextInformation(sequence, 674, 721);
-                TestSourceTextInformation(sequence.Elements[0], 674, 681);
-                TestSourceTextInformation(sequence.Elements[1], 684, 693);
-                TestSourceTextInformation(sequence.Elements[2], 696, 703);
-                TestSourceTextInformation(sequence.Elements[3], 706, 715);
-                TestSourceTextInformation(sequence.Elements[4], 718, 721);
+                TestSourceTextInformation(sequence, 656, 703);
+                TestSourceTextInformation(sequence.Elements[0], 656, 663);
+                TestSourceTextInformation(sequence.Elements[1], 666, 675);
+                TestSourceTextInformation(sequence.Elements[2], 678, 685);
+                TestSourceTextInformation(sequence.Elements[3], 688, 697);
+                TestSourceTextInformation(sequence.Elements[4], 700, 703);
             }
             Pattern1();
             Pattern2();

--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -513,10 +513,11 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
     Pattern7(Q, S) = Pattern6(Q: X, S: Y);
     Pattern8(X) = [1+ X: Symbol + X];
     Pattern9(X, ~Y) = {X: Punct + X, Y: Symbol + Y};
+    Pattern10 = 'Hello' + WordBreak + 'World' + WordBreak + '!';
 }";
             var parser = new SyntaxParser();
             PackageSyntax package = parser.ParsePackageText(patterns);
-            TestSourceTextInformation(package, 0, 659);
+            TestSourceTextInformation(package, 0, 725);
             void Pattern1()
             {
                 var pattern = (PatternSyntax) package.Patterns[0];
@@ -583,100 +584,112 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
                 PatternB();
             }
             void Pattern3()
-             {
-                 var pattern3 = (PatternSyntax) package.Patterns[2];
-                 TestSourceTextInformation(pattern3, 290, 328);
-                 var sequence = (SequenceSyntax) pattern3.Body;
-                 TestSourceTextInformation(sequence, 301, 327);
-                 TestSourceTextInformation(sequence.Elements[0], 301, 313);
-                 var optionality = (OptionalitySyntax) sequence.Elements[1];
-                 TestSourceTextInformation(optionality, 316, 327);
-                 TestSourceTextInformation(optionality.Body, 318, 327);
-             }
+            {
+                var pattern3 = (PatternSyntax) package.Patterns[2];
+                TestSourceTextInformation(pattern3, 290, 328);
+                var sequence = (SequenceSyntax) pattern3.Body;
+                TestSourceTextInformation(sequence, 301, 327);
+                TestSourceTextInformation(sequence.Elements[0], 301, 313);
+                var optionality = (OptionalitySyntax) sequence.Elements[1];
+                TestSourceTextInformation(optionality, 316, 327);
+                TestSourceTextInformation(optionality.Body, 318, 327);
+            }
             void Pattern4()
-             {
-                 var pattern4 = (PatternSyntax) package.Patterns[3];
-                 TestSourceTextInformation(pattern4, 334, 409);
-                 var wordSpan = (WordSpanSyntax) pattern4.Body;
-                 TestSourceTextInformation(wordSpan, 362, 408);
-                 TestSourceTextInformation(wordSpan.Left, 362, 368);
-                 TestSourceTextInformation(wordSpan.Right, 381, 408);
-             }
+            {
+                var pattern4 = (PatternSyntax) package.Patterns[3];
+                TestSourceTextInformation(pattern4, 334, 409);
+                var wordSpan = (WordSpanSyntax) pattern4.Body;
+                TestSourceTextInformation(wordSpan, 362, 408);
+                TestSourceTextInformation(wordSpan.Left, 362, 368);
+                TestSourceTextInformation(wordSpan.Right, 381, 408);
+            }
             void Pattern5()
-             {
-                 var pattern5 = (PatternSyntax) package.Patterns[4];
-                 TestSourceTextInformation(pattern5, 415, 463);
-                 var inside = (InsideSyntax) pattern5.Body;
-                 TestSourceTextInformation(inside.Inner, 427, 434);
-                 TestSourceTextInformation(inside.Outer, 444, 461);
-                 var sequence = (SequenceSyntax) inside.Outer;
-                 TestSourceTextInformation(sequence.Elements[0], 444, 451);
-                 TestSourceTextInformation(sequence.Elements[1], 454, 461);   
-             }
+            {
+                var pattern5 = (PatternSyntax) package.Patterns[4];
+                TestSourceTextInformation(pattern5, 415, 463);
+                var inside = (InsideSyntax) pattern5.Body;
+                TestSourceTextInformation(inside.Inner, 427, 434);
+                TestSourceTextInformation(inside.Outer, 444, 461);
+                var sequence = (SequenceSyntax) inside.Outer;
+                TestSourceTextInformation(sequence.Elements[0], 444, 451);
+                TestSourceTextInformation(sequence.Elements[1], 454, 461);   
+            }
             void Pattern6()
-             {
-                 var pattern6 = (PatternSyntax) package.Patterns[5];
-                 TestSourceTextInformation(pattern6, 469, 519);
-                 TestSourceTextInformation(pattern6.Fields[0], 478, 479);
-                 TestSourceTextInformation(pattern6.Fields[1], 481, 482);
-                 var anySpan = (AnySpanSyntax) pattern6.Body;
-                 TestSourceTextInformation(anySpan, 486, 518);
-                 var xExtraction = (ExtractionSyntax) anySpan.Left;
-                 TestSourceTextInformation(xExtraction, 486, 501);
-                 TestSourceTextInformation(xExtraction.Body, 489, 501);
-                 var yExtraction = (ExtractionSyntax) anySpan.Right;
-                 TestSourceTextInformation(yExtraction, 506, 518);
-                 TestSourceTextInformation(yExtraction.Body, 509, 518);
-             }
+            {
+                var pattern6 = (PatternSyntax) package.Patterns[5];
+                TestSourceTextInformation(pattern6, 469, 519);
+                TestSourceTextInformation(pattern6.Fields[0], 478, 479);
+                TestSourceTextInformation(pattern6.Fields[1], 481, 482);
+                var anySpan = (AnySpanSyntax) pattern6.Body;
+                TestSourceTextInformation(anySpan, 486, 518);
+                var xExtraction = (ExtractionSyntax) anySpan.Left;
+                TestSourceTextInformation(xExtraction, 486, 501);
+                TestSourceTextInformation(xExtraction.Body, 489, 501);
+                var yExtraction = (ExtractionSyntax) anySpan.Right;
+                TestSourceTextInformation(yExtraction, 506, 518);
+                TestSourceTextInformation(yExtraction.Body, 509, 518);
+            }
             void Pattern7()
-             {
-                 var pattern7 = (PatternSyntax) package.Patterns[6];
-                 TestSourceTextInformation(pattern7, 525, 563);
-                 TestSourceTextInformation(pattern7.Fields[0], 534, 535);
-                 TestSourceTextInformation(pattern7.Fields[1], 537, 538);
-                 var patternReference = (PatternReferenceSyntax) pattern7.Body;
-                 TestSourceTextInformation(patternReference, 542, 562);
-                 TestSourceTextInformation(patternReference.ExtractionFromFields[0], 551, 555);
-                 TestSourceTextInformation(patternReference.ExtractionFromFields[1], 557, 561);
-             }
+            {
+                var pattern7 = (PatternSyntax) package.Patterns[6];
+                TestSourceTextInformation(pattern7, 525, 563);
+                TestSourceTextInformation(pattern7.Fields[0], 534, 535);
+                TestSourceTextInformation(pattern7.Fields[1], 537, 538);
+                var patternReference = (PatternReferenceSyntax) pattern7.Body;
+                TestSourceTextInformation(patternReference, 542, 562);
+                TestSourceTextInformation(patternReference.ExtractionFromFields[0], 551, 555);
+                TestSourceTextInformation(patternReference.ExtractionFromFields[1], 557, 561);
+            }
             void Pattern8()
-             {
-                 var pattern8 = (PatternSyntax) package.Patterns[7];
-                 TestSourceTextInformation(pattern8, 569, 602);
-                 TestSourceTextInformation(pattern8.Fields[0], 578, 579);
-                 var span = (SpanSyntax) pattern8.Body;
-                 TestSourceTextInformation(span, 583, 601);
-                 var repetition = (RepetitionSyntax) span.Elements[0];
-                 TestSourceTextInformation(repetition, 584, 600);
-                 var sequence = (SequenceSyntax) repetition.Body;
-                 TestSourceTextInformation(sequence, 587, 600);
-                 var extraction = (ExtractionSyntax) sequence.Elements[0];
-                 TestSourceTextInformation(extraction, 587, 596);
-                 TestSourceTextInformation(extraction.Body, 590, 596);
-                 Assert.AreEqual("X", extraction.FieldName);
-                 TestSourceTextInformation(sequence.Elements[1], 599, 600);
-             }
+            {
+                var pattern8 = (PatternSyntax) package.Patterns[7];
+                TestSourceTextInformation(pattern8, 569, 602);
+                TestSourceTextInformation(pattern8.Fields[0], 578, 579);
+                var span = (SpanSyntax) pattern8.Body;
+                TestSourceTextInformation(span, 583, 601);
+                var repetition = (RepetitionSyntax) span.Elements[0];
+                TestSourceTextInformation(repetition, 584, 600);
+                var sequence = (SequenceSyntax) repetition.Body;
+                TestSourceTextInformation(sequence, 587, 600);
+                var extraction = (ExtractionSyntax) sequence.Elements[0];
+                TestSourceTextInformation(extraction, 587, 596);
+                TestSourceTextInformation(extraction.Body, 590, 596);
+                Assert.AreEqual("X", extraction.FieldName);
+                TestSourceTextInformation(sequence.Elements[1], 599, 600);
+            }
             void Pattern9()
-             {
-                 var pattern9 = (PatternSyntax) package.Patterns[8];
-                 TestSourceTextInformation(pattern9, 608, 656);
-                 TestSourceTextInformation(pattern9.Fields[0], 617, 618);
-                 TestSourceTextInformation(pattern9.Fields[1], 620, 622);
-                 var variation = (VariationSyntax) pattern9.Body;
-                 TestSourceTextInformation(variation, 626, 655);
-                 var sequence1 = (SequenceSyntax) variation.Elements[0];
-                 TestSourceTextInformation(sequence1, 627, 639);
-                 var extractionX = (ExtractionSyntax) sequence1.Elements[0];
-                 TestSourceTextInformation(extractionX, 627, 635);
-                 TestSourceTextInformation(extractionX.Body, 630, 635);
-                 TestSourceTextInformation(sequence1.Elements[1], 638, 639);
-                 var sequence2 = (SequenceSyntax) variation.Elements[1];
-                 TestSourceTextInformation(sequence2, 641, 654);
-                 var extractionY = (ExtractionSyntax) sequence2.Elements[0];
-                 TestSourceTextInformation(extractionY, 641, 650);
-                 TestSourceTextInformation(extractionY.Body, 644, 650);
-                 TestSourceTextInformation(sequence2.Elements[1], 653, 654);
-             }
+            {
+                var pattern9 = (PatternSyntax) package.Patterns[8];
+                TestSourceTextInformation(pattern9, 608, 656);
+                TestSourceTextInformation(pattern9.Fields[0], 617, 618);
+                TestSourceTextInformation(pattern9.Fields[1], 620, 622);
+                var variation = (VariationSyntax) pattern9.Body;
+                TestSourceTextInformation(variation, 626, 655);
+                var sequence1 = (SequenceSyntax) variation.Elements[0];
+                TestSourceTextInformation(sequence1, 627, 639);
+                var extractionX = (ExtractionSyntax) sequence1.Elements[0];
+                TestSourceTextInformation(extractionX, 627, 635);
+                TestSourceTextInformation(extractionX.Body, 630, 635);
+                TestSourceTextInformation(sequence1.Elements[1], 638, 639);
+                var sequence2 = (SequenceSyntax) variation.Elements[1];
+                TestSourceTextInformation(sequence2, 641, 654);
+                var extractionY = (ExtractionSyntax) sequence2.Elements[0];
+                TestSourceTextInformation(extractionY, 641, 650);
+                TestSourceTextInformation(extractionY.Body, 644, 650);
+                TestSourceTextInformation(sequence2.Elements[1], 653, 654);
+            }
+            void Pattern10()
+            {
+                var pattern10 = (PatternSyntax) package.Patterns[9];
+                TestSourceTextInformation(pattern10, 662, 722);
+                var sequence = (SequenceSyntax) pattern10.Body;
+                TestSourceTextInformation(sequence, 674, 721);
+                TestSourceTextInformation(sequence.Elements[0], 674, 681);
+                TestSourceTextInformation(sequence.Elements[1], 684, 693);
+                TestSourceTextInformation(sequence.Elements[2], 696, 703);
+                TestSourceTextInformation(sequence.Elements[3], 706, 715);
+                TestSourceTextInformation(sequence.Elements[4], 718, 721);
+            }
             Pattern1();
             Pattern2();
             Pattern3();
@@ -686,6 +699,7 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             Pattern7();
             Pattern8();
             Pattern9();
+            Pattern10();
         }
     }
 }

--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -516,41 +516,40 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
 }";
             var parser = new SyntaxParser();
             PackageSyntax package = parser.ParsePackageText(patterns);
+            TestSourceTextInformation(package, 0, 659);
             void Pattern1()
             {
                 var pattern = (PatternSyntax) package.Patterns[0];
-                TestSourceTextInformation(pattern, 1, 4, 4, 5,
-@"Pattern1 = A + B @where {
-        A = Word + {'Foo', ~'Bar'};
-        B = [1+ Num(2-4) & 'Nezaboodka'];
-    };");
+                TestSourceTextInformation(pattern, 24, 137);
                 var sequence = (SequenceSyntax) pattern.Body;
-                TestSourceTextInformation(sequence.Elements[0], 1, 15, 1, 15, "A");
-                TestSourceTextInformation(sequence.Elements[1], 1, 19, 1, 19, "B");
+                TestSourceTextInformation(sequence, 35, 40);
+                TestSourceTextInformation(sequence.Elements[0], 35, 36);
+                TestSourceTextInformation(sequence.Elements[1], 39, 40);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 2, 8, 2, 34, "A = Word + {'Foo', ~'Bar'};");
+                    TestSourceTextInformation(patternA, 59, 86);
                     var sequence = (SequenceSyntax) patternA.Body;
-                    TestSourceTextInformation(sequence.Elements[0], 2, 12, 2, 15, "Word");
+                    TestSourceTextInformation(sequence, 63, 85);
+                    TestSourceTextInformation(sequence.Elements[0], 63, 67);
                     var variation = (VariationSyntax) sequence.Elements[1];
-                    TestSourceTextInformation(variation, 2, 19, 2, 33, "{'Foo', ~'Bar'}");
-                    TestSourceTextInformation(variation.Elements[0], 2, 20, 2, 24, "'Foo'");
+                    TestSourceTextInformation(variation, 70, 85);
+                    TestSourceTextInformation(variation.Elements[0], 71, 76);
                     var exception = (ExceptionSyntax) variation.Elements[1];
-                    TestSourceTextInformation(exception, 2, 27, 2, 32, "~'Bar'");
-                    TestSourceTextInformation(exception.Body, 2, 28, 2, 32, "'Bar'");
+                    TestSourceTextInformation(exception, 78, 84);
+                    TestSourceTextInformation(exception.Body, 79, 84);
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 3, 8, 3, 40, "B = [1+ Num(2-4) & 'Nezaboodka'];");
+                    TestSourceTextInformation(patternB, 96, 129);
                     var span = (SpanSyntax) patternB.Body;
-                    TestSourceTextInformation(span, 3, 12, 3, 39, "[1+ Num(2-4) & 'Nezaboodka']");
+                    TestSourceTextInformation(span, 100, 128);
                     var repetition = (RepetitionSyntax) span.Elements[0];
-                    TestSourceTextInformation(repetition, 3, 13, 3, 38, "1+ Num(2-4) & 'Nezaboodka'");
+                    TestSourceTextInformation(repetition, 101, 127);
                     var conjunction = (ConjunctionSyntax) repetition.Body;
-                    TestSourceTextInformation(conjunction.Elements[0], 3, 16, 3, 23, "Num(2-4)");
-                    TestSourceTextInformation(conjunction.Elements[1], 3, 27, 3, 38, "'Nezaboodka'");
+                    TestSourceTextInformation(conjunction.Elements[0], 104, 112);
+                    TestSourceTextInformation(conjunction.Elements[1], 115, 127);
                 }
                 PatternA();
                 PatternB();
@@ -558,132 +557,126 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern2()
             {
                 var pattern2 = (PatternSyntax) package.Patterns[1];
-                TestSourceTextInformation(pattern2, 6, 4, 9, 5, 
-@"Pattern2 = A _ B @where {
-        A = 'Company' @outside Pattern1.A;
-        B = Pattern1.B @having Alpha(2-10, TitleCase);
-    };");
+                TestSourceTextInformation(pattern2, 149, 282);
                 var wordSequence = (WordSequenceSyntax) pattern2.Body;
-                TestSourceTextInformation(wordSequence.Elements[0], 6, 15, 6, 15, "A");
-                TestSourceTextInformation(wordSequence.Elements[1], 6, 19, 6, 19, "B");
+                TestSourceTextInformation(wordSequence.Elements[0], 160, 161);
+                TestSourceTextInformation(wordSequence.Elements[1], 164, 165);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern2.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 7, 8, 7, 41, "A = 'Company' @outside Pattern1.A;");
+                    TestSourceTextInformation(patternA, 184,  218);
                     var outside = (OutsideSyntax) patternA.Body;
-                    TestSourceTextInformation(outside, 7, 12, 7, 40, "'Company' @outside Pattern1.A");
-                    TestSourceTextInformation(outside.Body, 7, 12, 7, 20, "'Company'");
-                    TestSourceTextInformation(outside.Exception, 7, 31, 7, 40, "Pattern1.A");
+                    TestSourceTextInformation(outside, 188, 217);
+                    TestSourceTextInformation(outside.Body, 188, 197);
+                    TestSourceTextInformation(outside.Exception, 207, 217);
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern2.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 8, 8, 8, 53, "B = Pattern1.B @having Alpha(2-10, TitleCase);");
+                    TestSourceTextInformation(patternB, 228, 274);
                     var having = (HavingSyntax)patternB.Body;
-                    TestSourceTextInformation(having, 8, 12, 8, 52, "Pattern1.B @having Alpha(2-10, TitleCase)");
-                    TestSourceTextInformation(having.Outer, 8, 12, 8, 21, "Pattern1.B");
-                    TestSourceTextInformation(having.Inner, 8, 31, 8, 52, "Alpha(2-10, TitleCase)");
+                    TestSourceTextInformation(having, 232, 273);
+                    TestSourceTextInformation(having.Outer, 232, 242);
+                    TestSourceTextInformation(having.Inner, 251, 273);
                 }
                 PatternA();
                 PatternB();
             }
             void Pattern3()
-            {
-                var pattern3 = (PatternSyntax) package.Patterns[2];
-                TestSourceTextInformation(pattern3, 11, 4, 11, 41, "Pattern3 = 'Nezaboodka' + ? 'Company';");
-                var sequence = (SequenceSyntax) pattern3.Body;
-                TestSourceTextInformation(sequence, 11, 15, 11, 40, "'Nezaboodka' + ? 'Company'");
-                TestSourceTextInformation(sequence.Elements[0], 11, 15, 11, 26, "'Nezaboodka'");
-                var optionality = (OptionalitySyntax) sequence.Elements[1];
-                TestSourceTextInformation(optionality, 11, 30, 11, 40, "? 'Company'");
-                TestSourceTextInformation(optionality.Body, 11, 32, 11, 40, "'Company'");
-            }
+             {
+                 var pattern3 = (PatternSyntax) package.Patterns[2];
+                 TestSourceTextInformation(pattern3, 290, 328);
+                 var sequence = (SequenceSyntax) pattern3.Body;
+                 TestSourceTextInformation(sequence, 301, 327);
+                 TestSourceTextInformation(sequence.Elements[0], 301, 313);
+                 var optionality = (OptionalitySyntax) sequence.Elements[1];
+                 TestSourceTextInformation(optionality, 316, 327);
+                 TestSourceTextInformation(optionality.Body, 318, 327);
+             }
             void Pattern4()
-            {
-                var pattern4 = (PatternSyntax) package.Patterns[3];
-                TestSourceTextInformation(pattern4, 12, 4, 12, 78, "@search @pattern Pattern4 = 'Fo'!* .. [0-2] .. 'Ba'!*(Alpha, 1, Lowercase);");
-                var wordSpan = (WordSpanSyntax) pattern4.Body;
-                TestSourceTextInformation(wordSpan, 12, 32, 12, 77, "'Fo'!* .. [0-2] .. 'Ba'!*(Alpha, 1, Lowercase)");
-                TestSourceTextInformation(wordSpan.Left, 12, 32, 12, 37, "'Fo'!*");
-                TestSourceTextInformation(wordSpan.Right, 12, 51, 12, 77, "'Ba'!*(Alpha, 1, Lowercase)");
-            }
+             {
+                 var pattern4 = (PatternSyntax) package.Patterns[3];
+                 TestSourceTextInformation(pattern4, 334, 409);
+                 var wordSpan = (WordSpanSyntax) pattern4.Body;
+                 TestSourceTextInformation(wordSpan, 362, 408);
+                 TestSourceTextInformation(wordSpan.Left, 362, 368);
+                 TestSourceTextInformation(wordSpan.Right, 381, 408);
+             }
             void Pattern5()
-            {
-                var pattern5 = (PatternSyntax) package.Patterns[4];
-                TestSourceTextInformation(pattern5, 13, 4, 13, 51, "#Pattern5 = 'Hello' @inside ('Hello' + 'world');");
-                var inside = (InsideSyntax) pattern5.Body;
-                TestSourceTextInformation(inside.Inner, 13, 16, 13, 22, "'Hello'");
-                TestSourceTextInformation(inside.Outer, 13, 33, 13, 49, "'Hello' + 'world'");
-                var sequence = (SequenceSyntax) inside.Outer;
-                TestSourceTextInformation(sequence.Elements[0], 13, 33, 13, 39, "'Hello'");
-                TestSourceTextInformation(sequence.Elements[1], 13, 43, 13, 49, "'world'");   
-            }
+             {
+                 var pattern5 = (PatternSyntax) package.Patterns[4];
+                 TestSourceTextInformation(pattern5, 415, 463);
+                 var inside = (InsideSyntax) pattern5.Body;
+                 TestSourceTextInformation(inside.Inner, 427, 434);
+                 TestSourceTextInformation(inside.Outer, 444, 461);
+                 var sequence = (SequenceSyntax) inside.Outer;
+                 TestSourceTextInformation(sequence.Elements[0], 444, 451);
+                 TestSourceTextInformation(sequence.Elements[1], 454, 461);   
+             }
             void Pattern6()
-            {
-                var pattern6 = (PatternSyntax) package.Patterns[5];
-                TestSourceTextInformation(pattern6, 14, 4, 14, 53, "Pattern6(X, Y) = X: 'Nezaboodka' ... Y: 'Company';");
-                TestSourceTextInformation(pattern6.Fields[0], 14, 13, 14, 13, "X");
-                TestSourceTextInformation(pattern6.Fields[1], 14, 16, 14, 16, "Y");
-                var anySpan = (AnySpanSyntax) pattern6.Body;
-                TestSourceTextInformation(anySpan, 14, 21, 14, 52, "X: 'Nezaboodka' ... Y: 'Company'");
-                var xExtraction = (ExtractionSyntax) anySpan.Left;
-                TestSourceTextInformation(xExtraction, 14, 21, 14, 35, "X: 'Nezaboodka'");
-                TestSourceTextInformation(xExtraction.Body, 14, 24, 14, 35, "'Nezaboodka'");
-                var yExtraction = (ExtractionSyntax) anySpan.Right;
-                TestSourceTextInformation(yExtraction, 14, 41, 14, 52, "Y: 'Company'");
-                TestSourceTextInformation(yExtraction.Body, 14, 44, 14, 52, "'Company'");
-            }
+             {
+                 var pattern6 = (PatternSyntax) package.Patterns[5];
+                 TestSourceTextInformation(pattern6, 469, 519);
+                 TestSourceTextInformation(pattern6.Fields[0], 478, 479);
+                 TestSourceTextInformation(pattern6.Fields[1], 481, 482);
+                 var anySpan = (AnySpanSyntax) pattern6.Body;
+                 TestSourceTextInformation(anySpan, 486, 518);
+                 var xExtraction = (ExtractionSyntax) anySpan.Left;
+                 TestSourceTextInformation(xExtraction, 486, 501);
+                 TestSourceTextInformation(xExtraction.Body, 489, 501);
+                 var yExtraction = (ExtractionSyntax) anySpan.Right;
+                 TestSourceTextInformation(yExtraction, 506, 518);
+                 TestSourceTextInformation(yExtraction.Body, 509, 518);
+             }
             void Pattern7()
-            {
-                var pattern7 = (PatternSyntax) package.Patterns[6];
-                TestSourceTextInformation(pattern7, 15, 4, 15, 41, "Pattern7(Q, S) = Pattern6(Q: X, S: Y);");
-                TestSourceTextInformation(pattern7.Fields[0], 15, 13, 15, 13, "Q");
-                TestSourceTextInformation(pattern7.Fields[1], 15, 16, 15, 16, "S");
-                var patternReference = (PatternReferenceSyntax) pattern7.Body;
-                TestSourceTextInformation(patternReference, 15, 21, 15, 40, "Pattern6(Q: X, S: Y)");
-                var extractionQ = (ExtractionFromFieldSyntax) patternReference.ExtractionFromFields[0];
-                TestSourceTextInformation(extractionQ, 15, 30, 15, 33, "Q: X");
-                var extractionS = (ExtractionFromFieldSyntax) patternReference.ExtractionFromFields[1];
-                TestSourceTextInformation(extractionS, 15, 36, 15, 39, "S: Y");
-            }
+             {
+                 var pattern7 = (PatternSyntax) package.Patterns[6];
+                 TestSourceTextInformation(pattern7, 525, 563);
+                 TestSourceTextInformation(pattern7.Fields[0], 534, 535);
+                 TestSourceTextInformation(pattern7.Fields[1], 537, 538);
+                 var patternReference = (PatternReferenceSyntax) pattern7.Body;
+                 TestSourceTextInformation(patternReference, 542, 562);
+                 TestSourceTextInformation(patternReference.ExtractionFromFields[0], 551, 555);
+                 TestSourceTextInformation(patternReference.ExtractionFromFields[1], 557, 561);
+             }
             void Pattern8()
-            {
-                var pattern8 = (PatternSyntax) package.Patterns[7];
-                TestSourceTextInformation(pattern8, 16, 4, 16, 36, "Pattern8(X) = [1+ X: Symbol + X];");
-                TestSourceTextInformation(pattern8.Fields[0], 16, 13, 16, 13, "X");
-                var span = (SpanSyntax) pattern8.Body;
-                TestSourceTextInformation(span, 16, 18, 16, 35, "[1+ X: Symbol + X]");
-                var repetition = (RepetitionSyntax) span.Elements[0];
-                TestSourceTextInformation(repetition, 16, 19, 16, 34, "1+ X: Symbol + X");
-                var sequence = (SequenceSyntax) repetition.Body;
-                TestSourceTextInformation(sequence, 16, 22, 16, 34, "X: Symbol + X");
-                var extraction = (ExtractionSyntax) sequence.Elements[0];
-                TestSourceTextInformation(extraction, 16, 22, 16, 30, "X: Symbol");
-                TestSourceTextInformation(extraction.Body, 16, 25, 16, 30, "Symbol");
-                Assert.AreEqual("X", extraction.FieldName);
-                TestSourceTextInformation(sequence.Elements[1], 16, 34, 16, 34, "X");
-            }
+             {
+                 var pattern8 = (PatternSyntax) package.Patterns[7];
+                 TestSourceTextInformation(pattern8, 569, 602);
+                 TestSourceTextInformation(pattern8.Fields[0], 578, 579);
+                 var span = (SpanSyntax) pattern8.Body;
+                 TestSourceTextInformation(span, 583, 601);
+                 var repetition = (RepetitionSyntax) span.Elements[0];
+                 TestSourceTextInformation(repetition, 584, 600);
+                 var sequence = (SequenceSyntax) repetition.Body;
+                 TestSourceTextInformation(sequence, 587, 600);
+                 var extraction = (ExtractionSyntax) sequence.Elements[0];
+                 TestSourceTextInformation(extraction, 587, 596);
+                 TestSourceTextInformation(extraction.Body, 590, 596);
+                 Assert.AreEqual("X", extraction.FieldName);
+                 TestSourceTextInformation(sequence.Elements[1], 599, 600);
+             }
             void Pattern9()
-            {
-                var pattern9 = (PatternSyntax) package.Patterns[8];
-                TestSourceTextInformation(pattern9, 17, 4, 17, 51, "Pattern9(X, ~Y) = {X: Punct + X, Y: Symbol + Y};");
-                TestSourceTextInformation(pattern9.Fields[0], 17, 13, 17, 13, "X");
-                TestSourceTextInformation(pattern9.Fields[1], 17, 16, 17, 17, "~Y");
-                var variation = (VariationSyntax) pattern9.Body;
-                TestSourceTextInformation(variation, 17, 22, 17, 50, "{X: Punct + X, Y: Symbol + Y}");
-                var sequence1 = (SequenceSyntax) variation.Elements[0];
-                TestSourceTextInformation(sequence1, 17, 23, 17, 34, "X: Punct + X");
-                var extractionX = (ExtractionSyntax) sequence1.Elements[0];
-                TestSourceTextInformation(extractionX, 17, 23, 17, 30, "X: Punct");
-                TestSourceTextInformation(extractionX.Body, 17, 26, 17, 30, "Punct");
-                TestSourceTextInformation(sequence1.Elements[1], 17, 34, 17, 34, "X");
-                var sequence2 = (SequenceSyntax) variation.Elements[1];
-                TestSourceTextInformation(sequence2, 17, 37, 17, 49, "Y: Symbol + Y");
-                var extractionY = (ExtractionSyntax) sequence2.Elements[0];
-                TestSourceTextInformation(extractionY, 17, 37, 17, 45, "Y: Symbol");
-                TestSourceTextInformation(extractionY.Body, 17, 40, 17, 45, "Symbol");
-                TestSourceTextInformation(sequence2.Elements[1], 17, 49, 17, 49, "Y");
-            }
+             {
+                 var pattern9 = (PatternSyntax) package.Patterns[8];
+                 TestSourceTextInformation(pattern9, 608, 656);
+                 TestSourceTextInformation(pattern9.Fields[0], 617, 618);
+                 TestSourceTextInformation(pattern9.Fields[1], 620, 622);
+                 var variation = (VariationSyntax) pattern9.Body;
+                 TestSourceTextInformation(variation, 626, 655);
+                 var sequence1 = (SequenceSyntax) variation.Elements[0];
+                 TestSourceTextInformation(sequence1, 627, 639);
+                 var extractionX = (ExtractionSyntax) sequence1.Elements[0];
+                 TestSourceTextInformation(extractionX, 627, 635);
+                 TestSourceTextInformation(extractionX.Body, 630, 635);
+                 TestSourceTextInformation(sequence1.Elements[1], 638, 639);
+                 var sequence2 = (SequenceSyntax) variation.Elements[1];
+                 TestSourceTextInformation(sequence2, 641, 654);
+                 var extractionY = (ExtractionSyntax) sequence2.Elements[0];
+                 TestSourceTextInformation(extractionY, 641, 650);
+                 TestSourceTextInformation(extractionY.Body, 644, 650);
+                 TestSourceTextInformation(sequence2.Elements[1], 653, 654);
+             }
             Pattern1();
             Pattern2();
             Pattern3();

--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -521,18 +521,18 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern1()
             {
                 var pattern = (PatternSyntax) package.Patterns[0];
-                TestSourceTextInformation(pattern, 23, 133);
+                TestSourceTextInformation(pattern, 23, 143);
                 var sequence = (SequenceSyntax) pattern.Body;
-                TestSourceTextInformation(sequence, 34, 39);
-                TestSourceTextInformation(sequence.Elements[0], 34, 35);
-                TestSourceTextInformation(sequence.Elements[1], 38, 39);
+                TestSourceTextInformation(sequence, 34, 40);
+                TestSourceTextInformation(sequence.Elements[0], 34, 36);
+                TestSourceTextInformation(sequence.Elements[1], 38, 40);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 57, 84);
+                    TestSourceTextInformation(patternA, 57, 93);
                     var sequence = (SequenceSyntax) patternA.Body;
                     TestSourceTextInformation(sequence, 61, 83);
-                    TestSourceTextInformation(sequence.Elements[0], 61, 65);
+                    TestSourceTextInformation(sequence.Elements[0], 61, 66);
                     var variation = (VariationSyntax) sequence.Elements[1];
                     TestSourceTextInformation(variation, 68, 83);
                     TestSourceTextInformation(variation.Elements[0], 69, 74);
@@ -543,13 +543,13 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 93, 126);
+                    TestSourceTextInformation(patternB, 93, 131);
                     var span = (SpanSyntax) patternB.Body;
                     TestSourceTextInformation(span, 97, 125);
                     var repetition = (RepetitionSyntax) span.Elements[0];
                     TestSourceTextInformation(repetition, 98, 124);
                     var conjunction = (ConjunctionSyntax) repetition.Body;
-                    TestSourceTextInformation(conjunction.Elements[0], 101, 109);
+                    TestSourceTextInformation(conjunction.Elements[0], 101, 110);
                     TestSourceTextInformation(conjunction.Elements[1], 112, 124);
                 }
                 PatternA();
@@ -558,26 +558,26 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern2()
             {
                 var pattern2 = (PatternSyntax) package.Patterns[1];
-                TestSourceTextInformation(pattern2, 143, 273);
+                TestSourceTextInformation(pattern2, 143, 279);
                 var wordSequence = (WordSequenceSyntax) pattern2.Body;
-                TestSourceTextInformation(wordSequence.Elements[0], 154, 155);
-                TestSourceTextInformation(wordSequence.Elements[1], 158, 159);
+                TestSourceTextInformation(wordSequence.Elements[0], 154, 156);
+                TestSourceTextInformation(wordSequence.Elements[1], 158, 160);
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern2.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 177,  211);
+                    TestSourceTextInformation(patternA, 177,  220);
                     var outside = (OutsideSyntax) patternA.Body;
                     TestSourceTextInformation(outside, 181, 210);
-                    TestSourceTextInformation(outside.Body, 181, 190);
+                    TestSourceTextInformation(outside.Body, 181, 191);
                     TestSourceTextInformation(outside.Exception, 200, 210);
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern2.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 220, 266);
+                    TestSourceTextInformation(patternB, 220, 271);
                     var having = (HavingSyntax)patternB.Body;
                     TestSourceTextInformation(having, 224, 265);
-                    TestSourceTextInformation(having.Outer, 224, 234);
+                    TestSourceTextInformation(having.Outer, 224, 235);
                     TestSourceTextInformation(having.Inner, 243, 265);
                 }
                 PatternA();
@@ -586,10 +586,10 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern3()
             {
                 var pattern3 = (PatternSyntax) package.Patterns[2];
-                TestSourceTextInformation(pattern3, 279, 317);
+                TestSourceTextInformation(pattern3, 279, 322);
                 var sequence = (SequenceSyntax) pattern3.Body;
                 TestSourceTextInformation(sequence, 290, 316);
-                TestSourceTextInformation(sequence.Elements[0], 290, 302);
+                TestSourceTextInformation(sequence.Elements[0], 290, 303);
                 var optionality = (OptionalitySyntax) sequence.Elements[1];
                 TestSourceTextInformation(optionality, 305, 316);
                 TestSourceTextInformation(optionality.Body, 307, 316);
@@ -597,34 +597,34 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern4()
             {
                 var pattern4 = (PatternSyntax) package.Patterns[3];
-                TestSourceTextInformation(pattern4, 322, 397);
+                TestSourceTextInformation(pattern4, 322, 402);
                 var wordSpan = (WordSpanSyntax) pattern4.Body;
                 TestSourceTextInformation(wordSpan, 350, 396);
-                TestSourceTextInformation(wordSpan.Left, 350, 356);
+                TestSourceTextInformation(wordSpan.Left, 350, 357);
                 TestSourceTextInformation(wordSpan.Right, 369, 396);
             }
             void Pattern5()
             {
                 var pattern5 = (PatternSyntax) package.Patterns[4];
-                TestSourceTextInformation(pattern5, 402, 450);
+                TestSourceTextInformation(pattern5, 402, 455);
                 var inside = (InsideSyntax) pattern5.Body;
-                TestSourceTextInformation(inside.Inner, 414, 421);
+                TestSourceTextInformation(inside.Inner, 414, 422);
                 TestSourceTextInformation(inside.Outer, 431, 448);
                 var sequence = (SequenceSyntax) inside.Outer;
-                TestSourceTextInformation(sequence.Elements[0], 431, 438);
+                TestSourceTextInformation(sequence.Elements[0], 431, 439);
                 TestSourceTextInformation(sequence.Elements[1], 441, 448);   
             }
             void Pattern6()
             {
                 var pattern6 = (PatternSyntax) package.Patterns[5];
-                TestSourceTextInformation(pattern6, 455, 505);
+                TestSourceTextInformation(pattern6, 455, 510);
                 TestSourceTextInformation(pattern6.Fields[0], 464, 465);
                 TestSourceTextInformation(pattern6.Fields[1], 467, 468);
                 var anySpan = (AnySpanSyntax) pattern6.Body;
                 TestSourceTextInformation(anySpan, 472, 504);
                 var xExtraction = (ExtractionSyntax) anySpan.Left;
-                TestSourceTextInformation(xExtraction, 472, 487);
-                TestSourceTextInformation(xExtraction.Body, 475, 487);
+                TestSourceTextInformation(xExtraction, 472, 488);
+                TestSourceTextInformation(xExtraction.Body, 475, 488);
                 var yExtraction = (ExtractionSyntax) anySpan.Right;
                 TestSourceTextInformation(yExtraction, 492, 504);
                 TestSourceTextInformation(yExtraction.Body, 495, 504);
@@ -632,7 +632,7 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern7()
             {
                 var pattern7 = (PatternSyntax) package.Patterns[6];
-                TestSourceTextInformation(pattern7, 510, 548);
+                TestSourceTextInformation(pattern7, 510, 553);
                 TestSourceTextInformation(pattern7.Fields[0], 519, 520);
                 TestSourceTextInformation(pattern7.Fields[1], 522, 523);
                 var patternReference = (PatternReferenceSyntax) pattern7.Body;
@@ -643,7 +643,7 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern8()
             {
                 var pattern8 = (PatternSyntax) package.Patterns[7];
-                TestSourceTextInformation(pattern8, 553, 586);
+                TestSourceTextInformation(pattern8, 553, 591);
                 TestSourceTextInformation(pattern8.Fields[0], 562, 563);
                 var span = (SpanSyntax) pattern8.Body;
                 TestSourceTextInformation(span, 567, 585);
@@ -652,15 +652,14 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
                 var sequence = (SequenceSyntax) repetition.Body;
                 TestSourceTextInformation(sequence, 571, 584);
                 var extraction = (ExtractionSyntax) sequence.Elements[0];
-                TestSourceTextInformation(extraction, 571, 580);
-                TestSourceTextInformation(extraction.Body, 574, 580);
-                Assert.AreEqual("X", extraction.FieldName);
+                TestSourceTextInformation(extraction, 571, 581);
+                TestSourceTextInformation(extraction.Body, 574, 581);
                 TestSourceTextInformation(sequence.Elements[1], 583, 584);
             }
             void Pattern9()
             {
                 var pattern9 = (PatternSyntax) package.Patterns[8];
-                TestSourceTextInformation(pattern9, 591, 639);
+                TestSourceTextInformation(pattern9, 591, 644);
                 TestSourceTextInformation(pattern9.Fields[0], 600, 601);
                 TestSourceTextInformation(pattern9.Fields[1], 603, 605);
                 var variation = (VariationSyntax) pattern9.Body;
@@ -668,26 +667,26 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
                 var sequence1 = (SequenceSyntax) variation.Elements[0];
                 TestSourceTextInformation(sequence1, 610, 622);
                 var extractionX = (ExtractionSyntax) sequence1.Elements[0];
-                TestSourceTextInformation(extractionX, 610, 618);
-                TestSourceTextInformation(extractionX.Body, 613, 618);
+                TestSourceTextInformation(extractionX, 610, 619);
+                TestSourceTextInformation(extractionX.Body, 613, 619);
                 TestSourceTextInformation(sequence1.Elements[1], 621, 622);
                 var sequence2 = (SequenceSyntax) variation.Elements[1];
                 TestSourceTextInformation(sequence2, 624, 637);
                 var extractionY = (ExtractionSyntax) sequence2.Elements[0];
-                TestSourceTextInformation(extractionY, 624, 633);
-                TestSourceTextInformation(extractionY.Body, 627, 633);
+                TestSourceTextInformation(extractionY, 624, 634);
+                TestSourceTextInformation(extractionY.Body, 627, 634);
                 TestSourceTextInformation(sequence2.Elements[1], 636, 637);
             }
             void Pattern10()
             {
                 var pattern10 = (PatternSyntax) package.Patterns[9];
-                TestSourceTextInformation(pattern10, 644, 704);
+                TestSourceTextInformation(pattern10, 644, 705);
                 var sequence = (SequenceSyntax) pattern10.Body;
                 TestSourceTextInformation(sequence, 656, 703);
-                TestSourceTextInformation(sequence.Elements[0], 656, 663);
-                TestSourceTextInformation(sequence.Elements[1], 666, 675);
-                TestSourceTextInformation(sequence.Elements[2], 678, 685);
-                TestSourceTextInformation(sequence.Elements[3], 688, 697);
+                TestSourceTextInformation(sequence.Elements[0], 656, 664);
+                TestSourceTextInformation(sequence.Elements[1], 666, 676);
+                TestSourceTextInformation(sequence.Elements[2], 678, 686);
+                TestSourceTextInformation(sequence.Elements[3], 688, 698);
                 TestSourceTextInformation(sequence.Elements[4], 700, 703);
             }
             Pattern1();

--- a/Source/Engine.Tests/TestHelper.cs
+++ b/Source/Engine.Tests/TestHelper.cs
@@ -321,5 +321,14 @@ namespace Nezaboodka.Nevod.Engine.Tests
             }
             return dataDir;
         }
+        
+        public static void TestSourceTextInformation(Syntax syntax, int startLine, int startCharacter, int endLine, int endCharacter, string text)
+        {
+            Assert.AreEqual(startLine, syntax.StartLine);
+            Assert.AreEqual(startCharacter, syntax.StartCharacter);
+            Assert.AreEqual(endLine, syntax.EndLine);
+            Assert.AreEqual(endCharacter, syntax.EndCharacter);
+            Assert.AreEqual(text, syntax.TextSlice.ToString());
+        }
     }
 }

--- a/Source/Engine.Tests/TestHelper.cs
+++ b/Source/Engine.Tests/TestHelper.cs
@@ -322,13 +322,10 @@ namespace Nezaboodka.Nevod.Engine.Tests
             return dataDir;
         }
         
-        public static void TestSourceTextInformation(Syntax syntax, int startLine, int startCharacter, int endLine, int endCharacter, string text)
+        public static void TestSourceTextInformation(Syntax syntax, int start, int end)
         {
-            Assert.AreEqual(startLine, syntax.StartLine);
-            Assert.AreEqual(startCharacter, syntax.StartCharacter);
-            Assert.AreEqual(endLine, syntax.EndLine);
-            Assert.AreEqual(endCharacter, syntax.EndCharacter);
-            Assert.AreEqual(text, syntax.TextSlice.ToString());
+            Assert.AreEqual(start, syntax.TextRange.Start);
+            Assert.AreEqual(end, syntax.TextRange.End);
         }
     }
 }

--- a/Source/Engine/PackageBuilder/SyntaxParser.cs
+++ b/Source/Engine/PackageBuilder/SyntaxParser.cs
@@ -98,11 +98,8 @@ namespace Nezaboodka.Nevod
             NextToken();
             int startPosition = fToken.TextSlice.Position;
             Syntax patternBody = ParseInsideOrOutsideOrHaving();
-            PatternSyntax pattern = Syntax.Pattern(isSearchTarget: true, "Pattern", patternBody, null);
-            pattern = SetTextRange(pattern, startPosition);
-            var result = Syntax.Package(pattern);
-            result = SetTextRange(result, startPosition);
-            return result;
+            PatternSyntax pattern = SetTextRange(Syntax.Pattern(isSearchTarget: true, "Pattern", patternBody, null), startPosition);
+            return SetTextRange(Syntax.Package(pattern), startPosition);
         }
 
         public Exception SyntaxError(string format)
@@ -170,8 +167,7 @@ namespace Nezaboodka.Nevod
             // 3. Pattern definitions within namespaces
             while (fToken.Id != TokenId.End)
                 ParseNamespacesAndPatterns();
-            var result = Syntax.Package(fRequiredPackages, fSearchTargets, fPatterns);
-            result = SetTextRange(result, startPosition);
+            PackageSyntax result = SetTextRange(Syntax.Package(fRequiredPackages, fSearchTargets, fPatterns), startPosition);
             fCurrentScope = null;
             fScopeStack = null;
             fRequiredPackages = null;
@@ -250,8 +246,7 @@ namespace Nezaboodka.Nevod
                 throw SyntaxError(TextResource.RequireOperatorIsNotAllowedInSinglePackageMode);
             ValidateToken(TokenId.Semicolon, TextResource.RequireDefinitionShouldEndWithSemicolon);
             NextToken();
-            result = SetTextRange(result, startPosition);
-            return result;
+            return SetTextRange(result, startPosition);
         }
 
         private void ParseNamespacesAndPatterns()
@@ -265,8 +260,7 @@ namespace Nezaboodka.Nevod
                 case TokenId.PatternKeyword:
                     int startPosition1 = fToken.TextSlice.Position;
                     NextToken();
-                    PatternSyntax pattern1 = ParsePattern(isSearchTarget: false);
-                    pattern1 = SetTextRange(pattern1, startPosition1);
+                    PatternSyntax pattern1 = SetTextRange(ParsePattern(isSearchTarget: false), startPosition1);
                     fPatterns.Add(pattern1);
                     break;
                 case TokenId.SearchKeyword:
@@ -275,8 +269,7 @@ namespace Nezaboodka.Nevod
                     if (fToken.Id == TokenId.PatternKeyword)
                     {
                         NextToken();
-                        PatternSyntax pattern2 = ParsePattern(isSearchTarget: true);
-                        pattern2 = SetTextRange(pattern2, startPosition2);
+                        PatternSyntax pattern2 = SetTextRange(ParsePattern(isSearchTarget: true), startPosition2);
                         fPatterns.Add(pattern2);
                     }
                     else
@@ -299,9 +292,7 @@ namespace Nezaboodka.Nevod
             string fullName = Syntax.GetFullName(fCurrentScope.Namespace, name);
             ValidateToken(TokenId.Semicolon, TextResource.SearchTargetDefinitionShouldEndWithSemicolon);
             NextToken();
-            var result = Syntax.SearchTarget(fullName);
-            result = SetTextRange(result, startPosition);
-            return result;
+            return SetTextRange(Syntax.SearchTarget(fullName), startPosition);
         }
 
         private void ParseNamespace()
@@ -404,7 +395,7 @@ namespace Nezaboodka.Nevod
                     NextToken();
                     pattern = new PatternSyntax(fCurrentScope.Namespace, fCurrentScope.MasterPatternName,
                         isSearchTarget, name, fields, body, nestedPatterns);
-                    pattern = SetTextRange(pattern, startPosition);
+                    SetTextRange(pattern, startPosition);
                     fPatternByName.Add(fullName, pattern);
                 }
                 else
@@ -427,8 +418,7 @@ namespace Nezaboodka.Nevod
                     case TokenId.PatternKeyword:
                         int startPosition1 = fToken.TextSlice.Position;
                         NextToken();
-                        PatternSyntax pattern1 = ParsePattern(isSearchTarget: false);
-                        pattern1 = SetTextRange(pattern1, startPosition1);
+                        PatternSyntax pattern1 = SetTextRange(ParsePattern(isSearchTarget: false), startPosition1);
                         nestedPatterns.Add(pattern1);
                         break;
                     case TokenId.SearchKeyword:
@@ -436,8 +426,7 @@ namespace Nezaboodka.Nevod
                         NextToken();
                         if (fToken.Id == TokenId.PatternKeyword)
                         {
-                            PatternSyntax pattern2 = ParsePattern(isSearchTarget: true);
-                            pattern2 = SetTextRange(pattern2, startPosition2);
+                            PatternSyntax pattern2 = SetTextRange(ParsePattern(isSearchTarget: true), startPosition2);
                             nestedPatterns.Add(pattern2);
                         }
                         else
@@ -477,7 +466,6 @@ namespace Nezaboodka.Nevod
                         fFieldByName.Add(name, field);
                         result.Add(field);
                         NextToken();
-                        // Needs to be called after NextToken because relies on fLastToken
                         SetTextRange(field, startPosition);
                     }
                     else
@@ -542,8 +530,7 @@ namespace Nezaboodka.Nevod
                     Syntax element = ParseAnySpanOrWordSpan();
                     elements.Add(element);
                 }
-                result = Syntax.Conjunction(elements);
-                result = SetTextRange(result, startPosition);
+                result = SetTextRange(Syntax.Conjunction(elements), startPosition);
             }
             return result;
         }
@@ -617,8 +604,7 @@ namespace Nezaboodka.Nevod
             {
                 if (fExtractedFields.Add(field))
                 {
-                    result = Syntax.Extraction(field);
-                    result = SetTextRange(result, startPosition);
+                    result = SetTextRange(Syntax.Extraction(field), startPosition);
                     fAccessibleFields.Add(field);
                 }
                 else
@@ -642,8 +628,7 @@ namespace Nezaboodka.Nevod
                     Syntax element = ParseSequence();
                     elements.Add(element);
                 }
-                result = Syntax.WordSequence(elements);
-                result = SetTextRange(result, startPosition);
+                result = SetTextRange(Syntax.WordSequence(elements), startPosition);
             }
             return result;
         }
@@ -661,8 +646,7 @@ namespace Nezaboodka.Nevod
                     Syntax element = ParsePrimaryExpression();
                     elements.Add(element);
                 }
-                result = Syntax.Sequence(elements);
-                result = SetTextRange(result, startPosition);
+                result = SetTextRange(Syntax.Sequence(elements), startPosition);
             }
             return result;
         }
@@ -688,8 +672,7 @@ namespace Nezaboodka.Nevod
                     int startPosition = fToken.TextSlice.Position;
                     NextToken();
                     Syntax body = ParsePrimaryExpression();
-                    result = Syntax.Optionality(body);
-                    result = SetTextRange(result, startPosition);
+                    result = SetTextRange(Syntax.Optionality(body), startPosition);
                     break;
                 case TokenId.Identifier:
                     result = ParseExtractionOrReference();
@@ -722,10 +705,8 @@ namespace Nezaboodka.Nevod
             while (fToken.Id == TokenId.Comma);
             ValidateToken(TokenId.CloseCurlyBrace, TextResource.CloseCurlyBraceOrCommaExpected);
             NextToken();
-            var result = Syntax.Variation(elements);
-            result = SetTextRange(result, startPosition);
             fAccessibleFields = fAccessibleFieldsStack.Pop();
-            return result;
+            return SetTextRange(Syntax.Variation(elements), startPosition);
         }
 
         private ExceptionSyntax ParseException()
@@ -735,10 +716,8 @@ namespace Nezaboodka.Nevod
             NextToken();
             fAccessibleFieldsStack.Push(new HashSet<FieldSyntax>(fAccessibleFields));
             Syntax body = ParseInsideOrOutsideOrHaving();
-            var result = Syntax.Exception(body);
-            result = SetTextRange(result, startPosition);
             fAccessibleFields = fAccessibleFieldsStack.Pop();
-            return result;
+            return SetTextRange(Syntax.Exception(body), startPosition);
         }
 
         private SpanSyntax ParseSpan()
@@ -759,9 +738,7 @@ namespace Nezaboodka.Nevod
             while (fToken.Id == TokenId.Comma);
             ValidateToken(TokenId.CloseSquareBracket, TextResource.CloseSquareBracketExpected);
             NextToken();
-            var result = Syntax.Span(elements);
-            result = SetTextRange(result, startPosition);
-            return result;
+            return SetTextRange(Syntax.Span(elements), startPosition);
         }
 
         private RepetitionSyntax ParseRepetition()
@@ -770,10 +747,9 @@ namespace Nezaboodka.Nevod
             fAccessibleFieldsStack.Push(new HashSet<FieldSyntax>(fAccessibleFields));
             Range repetitionRange = ParseNumericRange();
             Syntax body = ParseInsideOrOutsideOrHaving();
-            var result = Syntax.Repetition(repetitionRange.LowBound, repetitionRange.HighBound, body);
-            result = SetTextRange(result, startPosition);
             fAccessibleFields = fAccessibleFieldsStack.Pop();
-            return result;
+            var result = Syntax.Repetition(repetitionRange.LowBound, repetitionRange.HighBound, body);
+            return SetTextRange(result, startPosition);
         }
 
         private Range ParseNumericRange()
@@ -858,8 +834,7 @@ namespace Nezaboodka.Nevod
             }
             else
                 result = ParsePatternReference(name);
-            result = SetTextRange(result, startPosition);
-            return result;
+            return SetTextRange(result, startPosition);
         }
 
         private Syntax ParsePatternReference(string patternName)
@@ -944,8 +919,7 @@ namespace Nezaboodka.Nevod
                     ValidateToken(TokenId.Identifier, TextResource.FieldNameExpected);
                     string fromFieldName = fToken.TextSlice.ToString();
                     NextToken();
-                    result = Syntax.ExtractionFromField(field, fromFieldName);
-                    result = SetTextRange(result, startPosition);
+                    result = SetTextRange(Syntax.ExtractionFromField(field, fromFieldName), startPosition);
                     fExtractedFields.Add(field);
                     fAccessibleFields.Add(field);
                 }
@@ -971,8 +945,7 @@ namespace Nezaboodka.Nevod
             }
             else
                 result = Syntax.Text(text, isCaseSensitive, textIsPrefix);
-            result = SetTextRange(result, startPosition);
-            return result;
+            return SetTextRange(result, startPosition);
         }
 
         private string ParseStringLiteral(out bool isCaseSensitive, out bool textIsPrefix)

--- a/Source/Engine/PackageBuilder/SyntaxParser.cs
+++ b/Source/Engine/PackageBuilder/SyntaxParser.cs
@@ -903,8 +903,8 @@ namespace Nezaboodka.Nevod
                     result = pattern.Body switch
                     {
                         TokenSyntax token => new TokenSyntax(token.TokenKind, token.Text, token.IsCaseSensitive, token.TextIsPrefix, token.TokenAttributes),
-                        VariationSyntax variation => new VariationSyntax(variation.Elements, false),
-                        _ => throw SyntaxError(TextResource.UnknownStandardPattern, pattern)
+                        VariationSyntax variation => new VariationSyntax(variation.Elements, checkCanReduce: false),
+                        _ => throw SyntaxError(TextResource.InternalCompilerError)
                     };
             }
             else
@@ -1589,7 +1589,6 @@ namespace Nezaboodka.Nevod
         public const string ColonExpected = "Colon expected, but '{0}' found";
         public const string AssignmentExpected = "Assignment (:=) expected, but '{0}' found";
         public const string AttributesAreNotAllowedForStandardPattern = "Attributes are not allowed for standard pattern '{0}'";
-        public const string UnknownStandardPattern = "Unknown standard pattern: {0}";
         public const string WordAttributeExpected = "Word token attribute expected, but '{0}' found";
         public const string WordClassWasAlreadyDefined = "Word class was already defined";
         public const string CharacterCaseWasAlreadyDefined = "Character case was already defined";

--- a/Source/Engine/Syntax/Syntax.cs
+++ b/Source/Engine/Syntax/Syntax.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Nezaboodka.Text;
 
 namespace Nezaboodka.Nevod
 {
@@ -18,6 +19,11 @@ namespace Nezaboodka.Nevod
             return result;
         }
 
+        public Slice TextSlice { get; set; }
+        public int StartLine { get; set; }
+        public int StartCharacter { get; set; } 
+        public int EndLine { get; set; }
+        public int EndCharacter { get; set; }
         internal virtual bool CanReduce => false;
 
         internal virtual Syntax Reduce()

--- a/Source/Engine/Syntax/Syntax.cs
+++ b/Source/Engine/Syntax/Syntax.cs
@@ -19,7 +19,7 @@ namespace Nezaboodka.Nevod
             string result = SyntaxStringBuilder.SyntaxToString(this);
             return result;
         }
-        
+
         internal virtual bool CanReduce => false;
 
         internal virtual Syntax Reduce()

--- a/Source/Engine/Syntax/Syntax.cs
+++ b/Source/Engine/Syntax/Syntax.cs
@@ -7,23 +7,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Nezaboodka.Text;
 
 namespace Nezaboodka.Nevod
 {
     public abstract partial class Syntax
     {
+        public TextRange TextRange { get; set; } 
+        
         public override string ToString()
         {
             string result = SyntaxStringBuilder.SyntaxToString(this);
             return result;
         }
-
-        public Slice TextSlice { get; set; }
-        public int StartLine { get; set; }
-        public int StartCharacter { get; set; } 
-        public int EndLine { get; set; }
-        public int EndCharacter { get; set; }
+        
         internal virtual bool CanReduce => false;
 
         internal virtual Syntax Reduce()

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -16,7 +16,17 @@ namespace Nezaboodka.Nevod
         {
             Syntax result = null;
             if (node != null)
+            {
                 result = node.Accept(this);
+                if (!ReferenceEquals(result, node))
+                {
+                    result.StartLine = node.StartLine;
+                    result.StartCharacter = node.StartCharacter;
+                    result.EndLine = node.EndLine;
+                    result.EndCharacter = node.EndCharacter;
+                    result.TextSlice = node.TextSlice;
+                }
+            }
             return result;
         }
 

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -16,7 +16,10 @@ namespace Nezaboodka.Nevod
         {
             Syntax result = null;
             if (node != null)
+            {
                 result = node.Accept(this);
+                result.TextRange = node.TextRange;
+            }
             return result;
         }
 

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -16,17 +16,7 @@ namespace Nezaboodka.Nevod
         {
             Syntax result = null;
             if (node != null)
-            {
                 result = node.Accept(this);
-                if (!ReferenceEquals(result, node))
-                {
-                    result.StartLine = node.StartLine;
-                    result.StartCharacter = node.StartCharacter;
-                    result.EndLine = node.EndLine;
-                    result.EndCharacter = node.EndCharacter;
-                    result.TextSlice = node.TextSlice;
-                }
-            }
             return result;
         }
 

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -16,10 +16,7 @@ namespace Nezaboodka.Nevod
         {
             Syntax result = null;
             if (node != null)
-            {
                 result = node.Accept(this);
-                result.TextRange = node.TextRange;
-            }
             return result;
         }
 

--- a/Source/Engine/Syntax/TextRange.cs
+++ b/Source/Engine/Syntax/TextRange.cs
@@ -10,7 +10,9 @@
             Start = start;
             End = end;
         }
-
+        
+        public int Length => End - Start;
+        
         public bool IsEmpty => Start == End;
     }
 }

--- a/Source/Engine/Syntax/TextRange.cs
+++ b/Source/Engine/Syntax/TextRange.cs
@@ -2,8 +2,8 @@
 {
     public struct TextRange
     {
-        public int Start { get; set; }
-        public int End { get; set; }
+        public int Start { get; }
+        public int End { get; }
 
         public TextRange(int start, int end)
         {

--- a/Source/Engine/Syntax/TextRange.cs
+++ b/Source/Engine/Syntax/TextRange.cs
@@ -1,0 +1,16 @@
+﻿namespace Nezaboodka.Nevod
+{
+    public struct TextRange
+    {
+        public int Start { get; set; }
+        public int End { get; set; }
+
+        public TextRange(int start, int end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public bool IsEmpty => Start == End;
+    }
+}


### PR DESCRIPTION
It was necessary to modify NextTokenOrComment method, making it save previous token to the class field. Apparently there is a rule that after creating a syntax object parse methods call NextToken thus setting fToken to the next one. It's impossible to determine in parent syntax where it ends after last child syntax has been parsed. Having said that, it's required to call AttachSourceTextInformation after advancing to the next token, because it internally relies on fLastToken. TextRange struct has been introduced to keep information about star and end positions of Syntax objects.