### PR TITLE
Include @search keyword in search target TextRange

### DIFF
--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -514,43 +514,54 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
     Pattern8(X) = [1+ X: Symbol + X];
     Pattern9(X, ~Y) = {X: Punct + X, Y: Symbol + Y};
     Pattern10 = 'Hello' + WordBreak + 'World' + WordBreak + '!';
-}".Replace("\r\n", "\n"); // Use \n as line feeds to make positions platform-independent
+    @search Pattern10;
+}";
             var parser = new SyntaxParser();
             PackageSyntax package = parser.ParsePackageText(patterns);
-            TestSourceTextInformation(package, 0, 706);
+            TestSourceTextInformation(patterns, package, patterns);
             void Pattern1()
             {
                 var pattern = (PatternSyntax) package.Patterns[0];
-                TestSourceTextInformation(pattern, 23, 143);
+                TestSourceTextInformation(patterns, pattern, 
+@"Pattern1 = A + B @where {
+        A = Word + {'Foo', ~'Bar'};
+        B = [1+ Num(2-4) & 'Nezaboodka'];
+    };
+    
+    ");
                 var sequence = (SequenceSyntax) pattern.Body;
-                TestSourceTextInformation(sequence, 34, 40);
-                TestSourceTextInformation(sequence.Elements[0], 34, 36);
-                TestSourceTextInformation(sequence.Elements[1], 38, 40);
+                TestSourceTextInformation(patterns, sequence, @"A + B ");
+                TestSourceTextInformation(patterns, sequence.Elements[0], @"A ");
+                TestSourceTextInformation(patterns, sequence.Elements[1], @"B ");
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 57, 93);
+                    TestSourceTextInformation(patterns, patternA, 
+@"A = Word + {'Foo', ~'Bar'};
+        ");
                     var sequence = (SequenceSyntax) patternA.Body;
-                    TestSourceTextInformation(sequence, 61, 83);
-                    TestSourceTextInformation(sequence.Elements[0], 61, 66);
+                    TestSourceTextInformation(patterns, sequence, @"Word + {'Foo', ~'Bar'}");
+                    TestSourceTextInformation(patterns, sequence.Elements[0], @"Word ");
                     var variation = (VariationSyntax) sequence.Elements[1];
-                    TestSourceTextInformation(variation, 68, 83);
-                    TestSourceTextInformation(variation.Elements[0], 69, 74);
+                    TestSourceTextInformation(patterns, variation, @"{'Foo', ~'Bar'}");
+                    TestSourceTextInformation(patterns, variation.Elements[0], @"'Foo'");
                     var exception = (ExceptionSyntax) variation.Elements[1];
-                    TestSourceTextInformation(exception, 76, 82);
-                    TestSourceTextInformation(exception.Body, 77, 82);
+                    TestSourceTextInformation(patterns, exception, @"~'Bar'");
+                    TestSourceTextInformation(patterns, exception.Body, @"'Bar'");
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 93, 131);
+                    TestSourceTextInformation(patterns, patternB, 
+@"B = [1+ Num(2-4) & 'Nezaboodka'];
+    ");
                     var span = (SpanSyntax) patternB.Body;
-                    TestSourceTextInformation(span, 97, 125);
+                    TestSourceTextInformation(patterns, span, @"[1+ Num(2-4) & 'Nezaboodka']");
                     var repetition = (RepetitionSyntax) span.Elements[0];
-                    TestSourceTextInformation(repetition, 98, 124);
+                    TestSourceTextInformation(patterns, repetition, @"1+ Num(2-4) & 'Nezaboodka'");
                     var conjunction = (ConjunctionSyntax) repetition.Body;
-                    TestSourceTextInformation(conjunction.Elements[0], 101, 110);
-                    TestSourceTextInformation(conjunction.Elements[1], 112, 124);
+                    TestSourceTextInformation(patterns, conjunction.Elements[0], @"Num(2-4) ");
+                    TestSourceTextInformation(patterns, conjunction.Elements[1], @"'Nezaboodka'");
                 }
                 PatternA();
                 PatternB();
@@ -558,27 +569,37 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern2()
             {
                 var pattern2 = (PatternSyntax) package.Patterns[1];
-                TestSourceTextInformation(pattern2, 143, 279);
+                TestSourceTextInformation(patterns, pattern2, 
+@"Pattern2 = A _ B @where {
+        A = 'Company' @outside Pattern1.A;
+        B = Pattern1.B @having Alpha(2-10, TitleCase);
+    };
+
+    ");
                 var wordSequence = (WordSequenceSyntax) pattern2.Body;
-                TestSourceTextInformation(wordSequence.Elements[0], 154, 156);
-                TestSourceTextInformation(wordSequence.Elements[1], 158, 160);
+                TestSourceTextInformation(patterns, wordSequence.Elements[0], @"A ");
+                TestSourceTextInformation(patterns, wordSequence.Elements[1], @"B ");
                 void PatternA()
                 {
                     PatternSyntax patternA = pattern2.NestedPatterns[0];
-                    TestSourceTextInformation(patternA, 177,  220);
+                    TestSourceTextInformation(patterns, patternA, 
+@"A = 'Company' @outside Pattern1.A;
+        ");
                     var outside = (OutsideSyntax) patternA.Body;
-                    TestSourceTextInformation(outside, 181, 210);
-                    TestSourceTextInformation(outside.Body, 181, 191);
-                    TestSourceTextInformation(outside.Exception, 200, 210);
+                    TestSourceTextInformation(patterns, outside, @"'Company' @outside Pattern1.A");
+                    TestSourceTextInformation(patterns, outside.Body, @"'Company' ");
+                    TestSourceTextInformation(patterns, outside.Exception, @"Pattern1.A");
                 }
                 void PatternB()
                 {
                     PatternSyntax patternB = pattern2.NestedPatterns[1];
-                    TestSourceTextInformation(patternB, 220, 271);
+                    TestSourceTextInformation(patterns, patternB, 
+@"B = Pattern1.B @having Alpha(2-10, TitleCase);
+    ");
                     var having = (HavingSyntax)patternB.Body;
-                    TestSourceTextInformation(having, 224, 265);
-                    TestSourceTextInformation(having.Outer, 224, 235);
-                    TestSourceTextInformation(having.Inner, 243, 265);
+                    TestSourceTextInformation(patterns, having, @"Pattern1.B @having Alpha(2-10, TitleCase)");
+                    TestSourceTextInformation(patterns, having.Outer, @"Pattern1.B ");
+                    TestSourceTextInformation(patterns, having.Inner, @"Alpha(2-10, TitleCase)");
                 }
                 PatternA();
                 PatternB();
@@ -586,108 +607,130 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             void Pattern3()
             {
                 var pattern3 = (PatternSyntax) package.Patterns[2];
-                TestSourceTextInformation(pattern3, 279, 322);
+                TestSourceTextInformation(patterns, pattern3,
+@"Pattern3 = 'Nezaboodka' + ? 'Company';
+    ");
                 var sequence = (SequenceSyntax) pattern3.Body;
-                TestSourceTextInformation(sequence, 290, 316);
-                TestSourceTextInformation(sequence.Elements[0], 290, 303);
+                TestSourceTextInformation(patterns, sequence, @"'Nezaboodka' + ? 'Company'");
+                TestSourceTextInformation(patterns, sequence.Elements[0], @"'Nezaboodka' ");
                 var optionality = (OptionalitySyntax) sequence.Elements[1];
-                TestSourceTextInformation(optionality, 305, 316);
-                TestSourceTextInformation(optionality.Body, 307, 316);
+                TestSourceTextInformation(patterns, optionality, @"? 'Company'");
+                TestSourceTextInformation(patterns, optionality.Body, @"'Company'");
             }
             void Pattern4()
             {
                 var pattern4 = (PatternSyntax) package.Patterns[3];
-                TestSourceTextInformation(pattern4, 322, 402);
+                TestSourceTextInformation(patterns, pattern4, 
+@"@search @pattern Pattern4 = 'Fo'!* .. [0-2] .. 'Ba'!*(Alpha, 1, Lowercase);
+    ");
                 var wordSpan = (WordSpanSyntax) pattern4.Body;
-                TestSourceTextInformation(wordSpan, 350, 396);
-                TestSourceTextInformation(wordSpan.Left, 350, 357);
-                TestSourceTextInformation(wordSpan.Right, 369, 396);
+                TestSourceTextInformation(patterns, wordSpan, @"'Fo'!* .. [0-2] .. 'Ba'!*(Alpha, 1, Lowercase)");
+                TestSourceTextInformation(patterns, wordSpan.Left, @"'Fo'!* ");
+                TestSourceTextInformation(patterns, wordSpan.Right, @"'Ba'!*(Alpha, 1, Lowercase)");
             }
             void Pattern5()
             {
                 var pattern5 = (PatternSyntax) package.Patterns[4];
-                TestSourceTextInformation(pattern5, 402, 455);
+                TestSourceTextInformation(patterns, pattern5, 
+@"#Pattern5 = 'Hello' @inside ('Hello' + 'world');
+    ");
                 var inside = (InsideSyntax) pattern5.Body;
-                TestSourceTextInformation(inside.Inner, 414, 422);
-                TestSourceTextInformation(inside.Outer, 431, 448);
+                TestSourceTextInformation(patterns, inside.Inner, @"'Hello' ");
+                TestSourceTextInformation(patterns, inside.Outer, @"'Hello' + 'world'");
                 var sequence = (SequenceSyntax) inside.Outer;
-                TestSourceTextInformation(sequence.Elements[0], 431, 439);
-                TestSourceTextInformation(sequence.Elements[1], 441, 448);   
+                TestSourceTextInformation(patterns, sequence.Elements[0], @"'Hello' ");
+                TestSourceTextInformation(patterns, sequence.Elements[1], @"'world'");   
             }
             void Pattern6()
             {
                 var pattern6 = (PatternSyntax) package.Patterns[5];
-                TestSourceTextInformation(pattern6, 455, 510);
-                TestSourceTextInformation(pattern6.Fields[0], 464, 465);
-                TestSourceTextInformation(pattern6.Fields[1], 467, 468);
+                TestSourceTextInformation(patterns, pattern6, 
+@"Pattern6(X, Y) = X: 'Nezaboodka' ... Y: 'Company';
+    ");
+                TestSourceTextInformation(patterns, pattern6.Fields[0], @"X");
+                TestSourceTextInformation(patterns, pattern6.Fields[1], @"Y");
                 var anySpan = (AnySpanSyntax) pattern6.Body;
-                TestSourceTextInformation(anySpan, 472, 504);
+                TestSourceTextInformation(patterns, anySpan, @"X: 'Nezaboodka' ... Y: 'Company'");
                 var xExtraction = (ExtractionSyntax) anySpan.Left;
-                TestSourceTextInformation(xExtraction, 472, 488);
-                TestSourceTextInformation(xExtraction.Body, 475, 488);
+                TestSourceTextInformation(patterns, xExtraction, @"X: 'Nezaboodka' ");
+                TestSourceTextInformation(patterns, xExtraction.Body, @"'Nezaboodka' ");
                 var yExtraction = (ExtractionSyntax) anySpan.Right;
-                TestSourceTextInformation(yExtraction, 492, 504);
-                TestSourceTextInformation(yExtraction.Body, 495, 504);
+                TestSourceTextInformation(patterns, yExtraction, @"Y: 'Company'");
+                TestSourceTextInformation(patterns, yExtraction.Body, @"'Company'");
             }
             void Pattern7()
             {
                 var pattern7 = (PatternSyntax) package.Patterns[6];
-                TestSourceTextInformation(pattern7, 510, 553);
-                TestSourceTextInformation(pattern7.Fields[0], 519, 520);
-                TestSourceTextInformation(pattern7.Fields[1], 522, 523);
+                TestSourceTextInformation(patterns, pattern7, 
+@"Pattern7(Q, S) = Pattern6(Q: X, S: Y);
+    ");
+                TestSourceTextInformation(patterns, pattern7.Fields[0], @"Q");
+                TestSourceTextInformation(patterns, pattern7.Fields[1], @"S");
                 var patternReference = (PatternReferenceSyntax) pattern7.Body;
-                TestSourceTextInformation(patternReference, 527, 547);
-                TestSourceTextInformation(patternReference.ExtractionFromFields[0], 536, 540);
-                TestSourceTextInformation(patternReference.ExtractionFromFields[1], 542, 546);
+                TestSourceTextInformation(patterns, patternReference, @"Pattern6(Q: X, S: Y)");
+                TestSourceTextInformation(patterns, patternReference.ExtractionFromFields[0], @"Q: X");
+                TestSourceTextInformation(patterns, patternReference.ExtractionFromFields[1], @"S: Y");
             }
             void Pattern8()
             {
                 var pattern8 = (PatternSyntax) package.Patterns[7];
-                TestSourceTextInformation(pattern8, 553, 591);
-                TestSourceTextInformation(pattern8.Fields[0], 562, 563);
+                TestSourceTextInformation(patterns, pattern8, 
+@"Pattern8(X) = [1+ X: Symbol + X];
+    ");
+                TestSourceTextInformation(patterns, pattern8.Fields[0], @"X");
                 var span = (SpanSyntax) pattern8.Body;
-                TestSourceTextInformation(span, 567, 585);
+                TestSourceTextInformation(patterns, span, @"[1+ X: Symbol + X]");
                 var repetition = (RepetitionSyntax) span.Elements[0];
-                TestSourceTextInformation(repetition, 568, 584);
+                TestSourceTextInformation(patterns, repetition, @"1+ X: Symbol + X");
                 var sequence = (SequenceSyntax) repetition.Body;
-                TestSourceTextInformation(sequence, 571, 584);
+                TestSourceTextInformation(patterns, sequence, @"X: Symbol + X");
                 var extraction = (ExtractionSyntax) sequence.Elements[0];
-                TestSourceTextInformation(extraction, 571, 581);
-                TestSourceTextInformation(extraction.Body, 574, 581);
-                TestSourceTextInformation(sequence.Elements[1], 583, 584);
+                TestSourceTextInformation(patterns, extraction, @"X: Symbol ");
+                TestSourceTextInformation(patterns, extraction.Body, @"Symbol ");
+                TestSourceTextInformation(patterns, sequence.Elements[1], @"X");
             }
             void Pattern9()
             {
                 var pattern9 = (PatternSyntax) package.Patterns[8];
-                TestSourceTextInformation(pattern9, 591, 644);
-                TestSourceTextInformation(pattern9.Fields[0], 600, 601);
-                TestSourceTextInformation(pattern9.Fields[1], 603, 605);
+                TestSourceTextInformation(patterns, pattern9, 
+@"Pattern9(X, ~Y) = {X: Punct + X, Y: Symbol + Y};
+    ");
+                TestSourceTextInformation(patterns, pattern9.Fields[0], @"X");
+                TestSourceTextInformation(patterns, pattern9.Fields[1], @"~Y");
                 var variation = (VariationSyntax) pattern9.Body;
-                TestSourceTextInformation(variation, 609, 638);
+                TestSourceTextInformation(patterns, variation, @"{X: Punct + X, Y: Symbol + Y}");
                 var sequence1 = (SequenceSyntax) variation.Elements[0];
-                TestSourceTextInformation(sequence1, 610, 622);
+                TestSourceTextInformation(patterns, sequence1, @"X: Punct + X");
                 var extractionX = (ExtractionSyntax) sequence1.Elements[0];
-                TestSourceTextInformation(extractionX, 610, 619);
-                TestSourceTextInformation(extractionX.Body, 613, 619);
-                TestSourceTextInformation(sequence1.Elements[1], 621, 622);
+                TestSourceTextInformation(patterns, extractionX, @"X: Punct ");
+                TestSourceTextInformation(patterns, extractionX.Body, @"Punct ");
+                TestSourceTextInformation(patterns, sequence1.Elements[1], @"X");
                 var sequence2 = (SequenceSyntax) variation.Elements[1];
-                TestSourceTextInformation(sequence2, 624, 637);
+                TestSourceTextInformation(patterns, sequence2, @"Y: Symbol + Y");
                 var extractionY = (ExtractionSyntax) sequence2.Elements[0];
-                TestSourceTextInformation(extractionY, 624, 634);
-                TestSourceTextInformation(extractionY.Body, 627, 634);
-                TestSourceTextInformation(sequence2.Elements[1], 636, 637);
+                TestSourceTextInformation(patterns, extractionY, @"Y: Symbol ");
+                TestSourceTextInformation(patterns, extractionY.Body, @"Symbol ");
+                TestSourceTextInformation(patterns, sequence2.Elements[1], @"Y");
             }
             void Pattern10()
             {
                 var pattern10 = (PatternSyntax) package.Patterns[9];
-                TestSourceTextInformation(pattern10, 644, 705);
+                TestSourceTextInformation(patterns, pattern10, 
+@"Pattern10 = 'Hello' + WordBreak + 'World' + WordBreak + '!';
+    ");
                 var sequence = (SequenceSyntax) pattern10.Body;
-                TestSourceTextInformation(sequence, 656, 703);
-                TestSourceTextInformation(sequence.Elements[0], 656, 664);
-                TestSourceTextInformation(sequence.Elements[1], 666, 676);
-                TestSourceTextInformation(sequence.Elements[2], 678, 686);
-                TestSourceTextInformation(sequence.Elements[3], 688, 698);
-                TestSourceTextInformation(sequence.Elements[4], 700, 703);
+                TestSourceTextInformation(patterns, sequence, @"'Hello' + WordBreak + 'World' + WordBreak + '!'");
+                TestSourceTextInformation(patterns, sequence.Elements[0], @"'Hello' ");
+                TestSourceTextInformation(patterns, sequence.Elements[1], @"WordBreak ");
+                TestSourceTextInformation(patterns, sequence.Elements[2], @"'World' ");
+                TestSourceTextInformation(patterns, sequence.Elements[3], @"WordBreak ");
+                TestSourceTextInformation(patterns, sequence.Elements[4], @"'!'");
+            }
+            void PatternSearchTarget()
+            {
+                var patternSearchTarget = (SearchTargetSyntax) package.SearchTargets[0];
+                TestSourceTextInformation(patterns, patternSearchTarget, @"@search Pattern10;
+");
             }
             Pattern1();
             Pattern2();
@@ -699,6 +742,7 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
             Pattern8();
             Pattern9();
             Pattern10();
+            PatternSearchTarget();
         }
     }
 }

--- a/Source/Engine.Tests/TestHelper.cs
+++ b/Source/Engine.Tests/TestHelper.cs
@@ -322,10 +322,10 @@ namespace Nezaboodka.Nevod.Engine.Tests
             return dataDir;
         }
         
-        public static void TestSourceTextInformation(Syntax syntax, int start, int end)
+        public static void TestSourceTextInformation(string patterns, Syntax syntax, string expectedText)
         {
-            Assert.AreEqual(start, syntax.TextRange.Start);
-            Assert.AreEqual(end, syntax.TextRange.End);
+            string actualText = patterns.Substring(syntax.TextRange.Start, syntax.TextRange.Length);
+            Assert.AreEqual(expectedText, actualText);
         }
     }
 }

--- a/Source/Engine/PackageBuilder/SyntaxParser.cs
+++ b/Source/Engine/PackageBuilder/SyntaxParser.cs
@@ -274,7 +274,7 @@ namespace Nezaboodka.Nevod
                     }
                     else
                     {
-                        SearchTargetSyntax searchTarget = ParseSearchTarget();
+                        SearchTargetSyntax searchTarget = SetTextRange(ParseSearchTarget(), startPosition2);
                         fSearchTargets.Add(searchTarget);
                     }
                     break;


### PR DESCRIPTION
Fix issue where search keyword was not included in TextRange of search targets. Refactor tests to assert equality of two strings.