### PR TITLE
Fix ToString for search targets

### DIFF
--- a/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxParserTests.cs
@@ -482,6 +482,18 @@ Identifier = {Alpha, AlphaNum, '_'} + [0+ {Word, '_'}];";
         }
 
         [TestMethod]
+        public void PatternSearchTarget()
+        {
+            string patterns =
+@"@search Pattern;
+
+Pattern = 'Pattern';
+";
+            
+            TestParseAndToString(patterns);
+        }
+
+        [TestMethod]
         public void ParseAsPatternBody()
         {
             string pattern = "Start + Word";

--- a/Source/Engine/PackageBuilder/SyntaxParser.cs
+++ b/Source/Engine/PackageBuilder/SyntaxParser.cs
@@ -300,7 +300,7 @@ namespace Nezaboodka.Nevod
             }
             else
             {
-                PatternReferenceSyntax patternReference = SetTextRange(Syntax.PatternReference(fullName), startPosition);
+                PatternReferenceSyntax patternReference = SetTextRange(Syntax.PatternReference(name), startPosition);
                 result = Syntax.PatternSearchTarget(fullName, patternReference);
             }
             return SetTextRange(result, startPosition);

--- a/Source/Engine/Syntax/SyntaxStringBuilder.cs
+++ b/Source/Engine/Syntax/SyntaxStringBuilder.cs
@@ -94,9 +94,11 @@ namespace Nezaboodka.Nevod
             if (fParents.TryPeek(out Syntax parent))
             {
                 PackageSyntax package = (PackageSyntax)parent;
-                if (!package.Patterns.Any(x => ((PatternSyntax)x).FullName == node.SearchTarget))
+                if (!package.Patterns.Any(x => ((PatternSyntax)x).IsSearchTarget && ((PatternSyntax)x).FullName == node.SearchTarget))
                     WriteSearchTarget(node);
             }
+            else
+                WriteSearchTarget(node);
             return node;
         }
 
@@ -108,12 +110,10 @@ namespace Nezaboodka.Nevod
 
         private void WriteSearchTarget(SearchTargetSyntax node)
         {
-            fParents.Push(node);
-            Write('#');
+            Write("@search ");
             Write(node.SearchTarget);
             Write(';');
             WriteLineBreak();
-            fParents.Pop();
         }
 
         protected internal override Syntax VisitPattern(PatternSyntax node)


### PR DESCRIPTION
1. Fix incorrect ToString output by replacing # with @search.
2. Fix VisitPatternSearchTarget behavior of SyntaxStringBuilder.
3. Use actual name retrieved from source code for pattern reference in PatternSearchTarget instead of full name.