### PR TITLE
Move loading of required packages from parser to linker

### DIFF
--- a/Source/Engine.Tests/PackageBuilder/PatternLinkerTests.cs
+++ b/Source/Engine.Tests/PackageBuilder/PatternLinkerTests.cs
@@ -13,7 +13,7 @@ namespace Nezaboodka.Nevod.Engine.Tests
 P1 = 'Nezaboodka';
 P2 = P1;
 ";
-            var linker = new PatternLinker(linkRequiredPackages: false);
+            var linker = new PatternLinker();
             LinkedPackageSyntax package = linker.Link(new SyntaxParser().ParsePackageText(patterns));
             var p1 = (PatternSyntax) package.Patterns[0];
             var p2 = (PatternSyntax) package.Patterns[1];

--- a/Source/Engine.Tests/SearchEngine/BasicPatternsTests.cs
+++ b/Source/Engine.Tests/SearchEngine/BasicPatternsTests.cs
@@ -5,10 +5,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 using static Nezaboodka.Nevod.Engine.Tests.TestHelper;
 
@@ -47,19 +43,19 @@ namespace Nezaboodka.Nevod.Engine.Tests
             {
                 string patterns = $"@require '{dataDir}/Basic/Basic.np'; @search Basic.*;";
                 string text = "eqweqw 11 212 323 23 ";
-                var prc = new ResourceConsumption();
+                var lrc = new ResourceConsumption();
                 var grc = new ResourceConsumption();
                 var src = new ResourceConsumption();
-                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, prc, grc, src, "11", "212", "323", "23", "11 212 323 23");
+                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, lrc, grc, src, "11", "212", "323", "23", "11 212 323 23");
 
                 string patterns2 = $"@require '{dataDir}/Basic/Basic.np'; @search Basic.Time;";
                 string text2 = "I'll be back at 7";
-                var prc2 = new ResourceConsumption();
+                var lrc2 = new ResourceConsumption();
                 var grc2 = new ResourceConsumption();
                 var src2 = new ResourceConsumption();
-                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns2, text2, prc2, grc2, src2, "7");
-                Assert.IsTrue(prc2.ConsumedBytes * 10 < prc.ConsumedBytes, "Memory consumption degraded");
-                Assert.IsTrue(prc2.ElapsedMilliseconds * 10 < prc.ElapsedMilliseconds, "Performance degraded");
+                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns2, text2, lrc2, grc2, src2, "7");
+                Assert.IsTrue(lrc2.ConsumedBytes * 10 < lrc.ConsumedBytes, "Memory consumption degraded");
+                Assert.IsTrue(lrc2.ElapsedMilliseconds * 10 < lrc.ElapsedMilliseconds, "Performance degraded");
                 Assert.IsTrue(grc2.ConsumedBytes * 10 < grc.ConsumedBytes, "Memory consumption degraded");
                 Assert.IsTrue(grc2.ElapsedMilliseconds * 5 < grc.ElapsedMilliseconds, "Performance degraded");
             }
@@ -76,21 +72,21 @@ namespace Nezaboodka.Nevod.Engine.Tests
             string dataDir = TestHelper.GetBasicPackageDirectory();
             try
             {
-                var prc = new ResourceConsumption();
+                var lrc = new ResourceConsumption();
                 var grc = new ResourceConsumption();
                 var src = new ResourceConsumption();
 
                 string patterns = $"@require '{dataDir}/Basic/Basic.np'; @search Basic.*;";
                 string text = "eqweqw 11 212 323 23 ";
-                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, prc, grc, src, "11", "212", "323", "23", "11 212 323 23");
-                Console.WriteLine($"Package parsing: {prc.ElapsedMilliseconds} ms, allocated {prc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {prc.ConsumedBytes / 1_000_000 + 1} MB");
+                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, lrc, grc, src, "11", "212", "323", "23", "11 212 323 23");
+                Console.WriteLine($"Package linking: {lrc.ElapsedMilliseconds} ms, allocated {lrc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {lrc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Package generation: {grc.ElapsedMilliseconds} ms, allocated {grc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {grc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Text search: {src.ElapsedMilliseconds} ms, allocated {src.TotalAllocatedBytes / 1_000_000 + 1} MB, used {src.ConsumedBytes / 1_000_000 + 1} MB");
 
                 string patterns2 = $"@require '{dataDir}/Basic/Basic.np'; @search Basic.Time;";
                 string text2 = "I'll be back at 7";
-                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns2, text2, prc, grc, src, "7");
-                Console.WriteLine($"Package parsing: {prc.ElapsedMilliseconds} ms, allocated {prc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {prc.ConsumedBytes / 1_000_000 + 1} MB");
+                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns2, text2, lrc, grc, src, "7");
+                Console.WriteLine($"Package linking: {lrc.ElapsedMilliseconds} ms, allocated {lrc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {lrc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Package generation: {grc.ElapsedMilliseconds} ms, allocated {grc.TotalAllocatedBytes / 1_000_000 + 1} MB, used {grc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Text search: {src.ElapsedMilliseconds} ms, allocated {src.TotalAllocatedBytes / 1_000_000 + 1} MB, used {src.ConsumedBytes / 1_000_000 + 1} MB");
             }

--- a/Source/Engine.Tests/SearchEngine/DebuggingTests.cs
+++ b/Source/Engine.Tests/SearchEngine/DebuggingTests.cs
@@ -5,10 +5,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 using static Nezaboodka.Nevod.Engine.Tests.TestHelper;
 
@@ -26,11 +22,11 @@ namespace Nezaboodka.Nevod.Engine.Tests
                 string dataDir = TestHelper.GetBasicPackageDirectory();
                 string patterns = $"@require '{dataDir}/Basic/Basic.np'; @search Basic.*;";
                 string text = "11";
-                var prc = new ResourceConsumption();
+                var lrc = new ResourceConsumption();
                 var grc = new ResourceConsumption();
                 var src = new ResourceConsumption();
-                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, prc, grc, src, "11");
-                Console.WriteLine($"Package parsing:\t{prc.ElapsedMilliseconds} ms,\tallocated {prc.TotalAllocatedBytes / 1_000_000 + 1} MB,\tused {prc.ConsumedBytes / 1_000_000 + 1} MB");
+                SearchPatternsAndCheckMatchesAndMeasureResourceConsumption(patterns, text, lrc, grc, src, "11");
+                Console.WriteLine($"Package linking:\t{lrc.ElapsedMilliseconds} ms,\tallocated {lrc.TotalAllocatedBytes / 1_000_000 + 1} MB,\tused {lrc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Package generation:\t{grc.ElapsedMilliseconds} ms,\tallocated {grc.TotalAllocatedBytes / 1_000_000 + 1} MB,\tused {grc.ConsumedBytes / 1_000_000 + 1} MB");
                 Console.WriteLine($"Text search:\t{src.ElapsedMilliseconds} ms,\tallocated {src.TotalAllocatedBytes / 1_000_000 + 1} MB,\tused {src.ConsumedBytes / 1_000_000 + 1} MB");
             }

--- a/Source/Engine/PackageBuilder/NormalizingPatternLinker.cs
+++ b/Source/Engine/PackageBuilder/NormalizingPatternLinker.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -12,7 +11,12 @@ namespace Nezaboodka.Nevod
         private PatternSyntax fCurrentPattern;
         private List<Syntax> fAllPatterns;
 
-        public NormalizingPatternLinker(bool linkRequiredPackages) : base(linkRequiredPackages)
+        public NormalizingPatternLinker()
+        {
+        }
+        
+        public NormalizingPatternLinker(string baseDirectory, IPackageLoader requiredPackageLoader) 
+            : base(baseDirectory, requiredPackageLoader)
         {
         }
 

--- a/Source/Engine/PackageBuilder/PackageBuilder.cs
+++ b/Source/Engine/PackageBuilder/PackageBuilder.cs
@@ -13,17 +13,17 @@ namespace Nezaboodka.Nevod
 {
     public class PackageBuilder : IPackageLoader
     {
-        internal class FileParser
+        internal class FileLinker
         {
             public string FilePath;
-            public SyntaxParser Parser;
+            public PatternLinker Linker;
         }
 
         private PackageBuilderOptions fOptions;
         private string fBaseDirectory;
         private Func<string, string> fFileContentProvider;
         private PackageCache fPackageCache;
-        private Stack<FileParser> fDependencyStack;
+        private Stack<FileLinker> fDependencyStack;
 
         public PackageBuilder()
             : this(PackageBuilderOptions.Default, Environment.CurrentDirectory, new PackageCache(), LoadFileContent)
@@ -61,12 +61,12 @@ namespace Nezaboodka.Nevod
             fBaseDirectory = baseDirectory;
             fFileContentProvider = fileContentProvider;
             fPackageCache = packageCache;
-            fDependencyStack = new Stack<FileParser>();
+            fDependencyStack = new Stack<FileLinker>();
         }
 
         public PatternPackage BuildPackageFromText(string definition)
         {
-            var parser = new SyntaxParser(fBaseDirectory, this);
+            var parser = new SyntaxParser();
             PackageSyntax parsedTree = parser.ParsePackageText(definition);
             PatternPackage result = BuildPackageFromSyntax(parsedTree);
             return result;
@@ -74,29 +74,21 @@ namespace Nezaboodka.Nevod
 
         public PatternPackage BuildPackageFromFile(string filePath)
         {
-            PackageSyntax parsedTree = ParseFile(filePath);
-            PatternPackage result = BuildPackageFromSyntax(parsedTree);
+            string normalizedFilePath = Path.GetFullPath(filePath);
+            PackageSyntax parsedTree = ParseFile(normalizedFilePath);
+            PatternPackage result = BuildPackageFromSyntax(parsedTree, normalizedFilePath);
             return result;
         }
 
         public PatternPackage BuildPackageFromExpressionText(string expression)
         {
-            var parser = new SyntaxParser(fBaseDirectory, this);
+            var parser = new SyntaxParser();
             PackageSyntax parsedTree = parser.ParseExpressionText(expression);
             PatternPackage result = BuildPackageFromSyntax(parsedTree);
             return result;
         }
 
-        public PatternPackage BuildPackageFromSyntax(PackageSyntax parsedTree)
-        {
-            lock (fPackageCache)
-            {
-                LinkedPackageSyntax linkedTree = LinkPackage(parsedTree);
-                var generator = new PackageGenerator(fOptions.SyntaxInformationBinding, fPackageCache);
-                PatternPackage result = generator.Generate(linkedTree);
-                return result;
-            }
-        }
+        public PatternPackage BuildPackageFromSyntax(PackageSyntax parsedTree) => BuildPackageFromSyntax(parsedTree, null);
 
         // Internal
 
@@ -107,26 +99,47 @@ namespace Nezaboodka.Nevod
             if (!fPackageCache.PackageSyntaxByFilePath.TryGetValue(filePath, out result))
             {
                 PackageSyntax package = ParseFile(filePath);
-                result = LinkPackage(package);
+                string baseDirectory = Path.GetDirectoryName(filePath);
+                result = LinkPackage(package, baseDirectory, filePath);
+                result = SubstituteReferences(result);
                 fPackageCache.PackageSyntaxByFilePath.TryAdd(filePath, result);
             }
             return result;
+        }
+        
+        private PatternPackage BuildPackageFromSyntax(PackageSyntax parsedTree, string filePath)
+        {
+            lock (fPackageCache)
+            {
+                LinkedPackageSyntax linkedTree = LinkPackage(parsedTree, fBaseDirectory, filePath);
+                linkedTree = SubstituteReferences(linkedTree);
+                var generator = new PackageGenerator(fOptions.SyntaxInformationBinding, fPackageCache);
+                PatternPackage result = generator.Generate(linkedTree);
+                return result;
+            }
         }
 
         private PackageSyntax ParseFile(string filePath)
         {
             PackageSyntax result;
-            string baseDirectory = Path.GetDirectoryName(filePath);
-            var parser = new SyntaxParser(baseDirectory, this);
-            fDependencyStack.Push(new FileParser()
+            string text = fFileContentProvider(filePath);
+            var parser = new SyntaxParser();
+            result = parser.ParsePackageText(text);
+            return result;
+        }
+
+        private LinkedPackageSyntax LinkPackage(PackageSyntax parsedTree, string baseDirectory, string filePath)
+        {
+            LinkedPackageSyntax result;
+            var linker = new NormalizingPatternLinker(baseDirectory, requiredPackageLoader: this);
+            fDependencyStack.Push(new FileLinker()
             {
                 FilePath = filePath,
-                Parser = parser
+                Linker = linker
             });
-            string text = fFileContentProvider(filePath);
             try
             {
-                result = parser.ParsePackageText(text);
+                result = linker.Link(parsedTree);
             }
             catch (Exception ex)
             {
@@ -136,10 +149,8 @@ namespace Nezaboodka.Nevod
             return result;
         }
 
-        private LinkedPackageSyntax LinkPackage(PackageSyntax parsedTree)
+        private LinkedPackageSyntax SubstituteReferences(LinkedPackageSyntax linkedTree)
         {
-            var linker = new NormalizingPatternLinker(linkRequiredPackages: false);
-            LinkedPackageSyntax linkedTree = linker.Link(parsedTree);
             if (fOptions.PatternReferencesInlined)
             {
                 // Выполнить подстановку всех ссылок на шаблоны, кроме рекурсивных.
@@ -161,8 +172,8 @@ namespace Nezaboodka.Nevod
         {
             if (fDependencyStack.Any(x => x.FilePath == filePath))
             {
-                fDependencyStack.TryPeek(out FileParser lastParser);
-                throw lastParser.Parser.SyntaxError(TextResource.RecursiveFileDependencyIsNotSupported,
+                fDependencyStack.TryPeek(out FileLinker lastLinker);
+                throw lastLinker.Linker.SyntaxError(TextResource.RecursiveFileDependencyIsNotSupported,
                     string.Join(" -> ", fDependencyStack.Reverse().Select(x => x.FilePath)) + " -> " + filePath);
             }
         }

--- a/Source/Engine/PackageBuilder/PatternReferenceSubstitutor.cs
+++ b/Source/Engine/PackageBuilder/PatternReferenceSubstitutor.cs
@@ -3,11 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 //--------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 
 namespace Nezaboodka.Nevod
 {
@@ -27,10 +24,8 @@ namespace Nezaboodka.Nevod
             fExcludedPatterns = excludedPatterns;
             fVisitedPatterns = new HashSet<PatternSyntax>();
             fPatternSubstitutions = new Dictionary<PatternSyntax, PatternSyntax>();
-            LinkedPackageSyntax substitutedTree = (LinkedPackageSyntax)Visit(syntaxTree);
+            LinkedPackageSyntax result = (LinkedPackageSyntax)Visit(syntaxTree);
             fPatternSubstitutions.Clear();
-            var linker = new NormalizingPatternLinker(linkRequiredPackages: true);
-            LinkedPackageSyntax result = linker.Link(substitutedTree);
             return result;
         }
 

--- a/Source/Engine/PackageBuilder/SystemPatternReferenceSubstitutor.cs
+++ b/Source/Engine/PackageBuilder/SystemPatternReferenceSubstitutor.cs
@@ -3,11 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 //--------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 
 namespace Nezaboodka.Nevod
 {
@@ -20,10 +17,8 @@ namespace Nezaboodka.Nevod
         {
             fVisitedPatterns = new HashSet<PatternSyntax>();
             fSystemPatternSubstitutions = new Dictionary<PatternSyntax, PatternSyntax>();
-            LinkedPackageSyntax substitutedTree = (LinkedPackageSyntax)Visit(syntaxTree);
+            LinkedPackageSyntax result = (LinkedPackageSyntax)Visit(syntaxTree);
             fSystemPatternSubstitutions.Clear();
-            var linker = new NormalizingPatternLinker(linkRequiredPackages: true);
-            LinkedPackageSyntax result = linker.Link(substitutedTree);
             return result;
         }
 

--- a/Source/Engine/Syntax/RequiredPackageSyntax.cs
+++ b/Source/Engine/Syntax/RequiredPackageSyntax.cs
@@ -3,21 +3,16 @@
 // Licensed under the Apache License, Version 2.0.
 //--------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace Nezaboodka.Nevod
 {
     public class RequiredPackageSyntax : Syntax
     {
-        public string BaseDirectory { get; }
+        public string BaseDirectory { get; private set; }
         public string RelativePath { get; }
-        public string FullPath { get; }
-        public new LinkedPackageSyntax Package { get; }
+        public string FullPath { get; private set; }
+        public new LinkedPackageSyntax Package { get; private set; }
 
         internal RequiredPackageSyntax(string baseDirectory, string relativePath, LinkedPackageSyntax package)
         {
@@ -26,6 +21,11 @@ namespace Nezaboodka.Nevod
             FullPath = GetRequiredFilePath(baseDirectory, relativePath);
             Package = package;
         }
+        
+        internal RequiredPackageSyntax(string relativePath)
+        {
+            RelativePath = relativePath;
+        }
 
         internal RequiredPackageSyntax(RequiredPackageSyntax source, LinkedPackageSyntax package)
         {
@@ -33,6 +33,13 @@ namespace Nezaboodka.Nevod
             RelativePath = source.RelativePath;
             FullPath = source.FullPath;
             Package = package;
+        }
+
+        internal void SetRequiredPackage(LinkedPackageSyntax package, string baseDirectory)
+        {
+            Package = package;
+            BaseDirectory = baseDirectory;
+            FullPath = GetRequiredFilePath(baseDirectory, RelativePath);
         }
 
         internal RequiredPackageSyntax Update(LinkedPackageSyntax package)

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -18,7 +18,7 @@ namespace Nezaboodka.Nevod
             return result;
         }
 
-        public ReadOnlyCollection<T> Visit<T>(ReadOnlyCollection<T> nodes) where T : Syntax
+        public virtual ReadOnlyCollection<T> Visit<T>(ReadOnlyCollection<T> nodes) where T : Syntax
         {
             T[] newNodes = null;
             for (int i = 0, n = nodes.Count; i < n; i++)

--- a/Source/Engine/Syntax/SyntaxVisitor.cs
+++ b/Source/Engine/Syntax/SyntaxVisitor.cs
@@ -4,9 +4,7 @@
 //--------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
 
 namespace Nezaboodka.Nevod
 {
@@ -256,7 +254,7 @@ namespace Nezaboodka.Nevod
             return node;
         }
 
-        protected Exception SyntaxError(string format, params object[] args)
+        protected internal Exception SyntaxError(string format, params object[] args)
         {
             return new SyntaxException(string.Format(System.Globalization.CultureInfo.CurrentCulture, format, args), 0,
                 0, string.Empty);


### PR DESCRIPTION
1. Loading of required packages was moved to linker to make it possible to parse the file independently of its dependencies. Approach similar to resolving pattern references was used: in parser RequiredPackageSyntax is created with Pacakge field set to null. This value is resolved in linker using provided IPackageLoader.
2. Parsing consumption metrics in tests was replaced with linking consumption, because now parsing does not benefit from cache.
3. Redundant usage of NormalizingPatternLinker in reference substitutors was removed, as well as fLinkRequiredPackages field was removed from PatternLinker.