### PR TITLE
Set RuntimeFrameworkVersion to 3.1.20 to address missing rhel.6-x64 package issue

### DIFF
--- a/.github/workflows/nevod.yaml
+++ b/.github/workflows/nevod.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Test
         run: |
           dotnet test Source/Engine.Tests/Nezaboodka.Nevod.Engine.Tests.csproj -c Release --verbosity normal --test-adapter-path:. \
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Test
         run: |
           dotnet test Source/Negrep.Tests/Nezaboodka.Nevod.Negrep.Tests.csproj -c Release --verbosity normal --test-adapter-path:. \
@@ -75,7 +75,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Test
         run: dotnet test Source/Text.Tests/Nezaboodka.Text.Tests.csproj -c Release --verbosity normal
   
@@ -186,7 +186,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Set VERSION variable from tag
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Build
@@ -211,7 +211,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 3.1.414
       - name: Set VERSION variable from tag
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Build

--- a/.github/workflows/nevod.yaml
+++ b/.github/workflows/nevod.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Test
         run: |
           dotnet test Source/Engine.Tests/Nezaboodka.Nevod.Engine.Tests.csproj -c Release --verbosity normal --test-adapter-path:. \
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Test
         run: |
           dotnet test Source/Negrep.Tests/Nezaboodka.Nevod.Negrep.Tests.csproj -c Release --verbosity normal --test-adapter-path:. \
@@ -75,7 +75,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Test
         run: dotnet test Source/Text.Tests/Nezaboodka.Text.Tests.csproj -c Release --verbosity normal
   
@@ -186,7 +186,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Set VERSION variable from tag
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Build
@@ -211,7 +211,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.414
+          dotnet-version: 3.1.x
       - name: Set VERSION variable from tag
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Build

--- a/Source/Negrep/Nezaboodka.Nevod.Negrep.csproj
+++ b/Source/Negrep/Nezaboodka.Nevod.Negrep.csproj
@@ -9,6 +9,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>
     <RuntimeIdentifiers>alpine-x64;rhel.6-x64;osx-x64;win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeFrameworkVersion>3.1.20</RuntimeFrameworkVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
See here https://github.com/dotnet/core/issues/6884#issuecomment-965585900