### PR TITLE
Make file system case sensitivity configurable

### DIFF
--- a/Source/Engine.Tests/Syntax/LinkerErrorRecoveryTests.cs
+++ b/Source/Engine.Tests/Syntax/LinkerErrorRecoveryTests.cs
@@ -199,7 +199,8 @@ P1 = Word;
                 }
             }
             
-            if (!PathCaseNormalizer.IsFileSystemCaseSensitive)
+            var pathCaseNormalizer = new PathCaseNormalizer();
+            if (!pathCaseNormalizer.IsFileSystemCaseSensitive)
             {
                 LinkAndCompareErrors(
                     filePath: "Main.np",

--- a/Source/Engine/PackageBuilder/NormalizingPatternLinker.cs
+++ b/Source/Engine/PackageBuilder/NormalizingPatternLinker.cs
@@ -13,7 +13,13 @@ namespace Nezaboodka.Nevod
         private List<Syntax> fAllPatterns;
 
         public NormalizingPatternLinker(Func<string, string> fileContentProvider, PackageCache packageCache)
-            : base(fileContentProvider, packageCache)
+            : base(fileContentProvider, packageCache, isFileSystemCaseSensitive: null)
+        {
+        }
+
+        public NormalizingPatternLinker(Func<string, string> fileContentProvider, PackageCache packageCache, 
+            bool? isFileSystemCaseSensitive)
+            : base(fileContentProvider, packageCache, isFileSystemCaseSensitive)
         {
         }
 

--- a/Source/Engine/PackageBuilder/PackageBuilder.cs
+++ b/Source/Engine/PackageBuilder/PackageBuilder.cs
@@ -107,7 +107,7 @@ namespace Nezaboodka.Nevod
 
         private LinkedPackageSyntax LinkPackage(PackageSyntax parsedTree, string baseDirectory, string filePath)
         {
-            var linker = new NormalizingPatternLinker(fFileContentProvider, fPackageCache);
+            var linker = new NormalizingPatternLinker(fFileContentProvider, fPackageCache, fOptions.IsFileSystemCaseSensitive);
             LinkedPackageSyntax result = linker.Link(parsedTree, baseDirectory, filePath);
             return result;
         }

--- a/Source/Engine/PackageBuilder/PackageBuilderOptions.cs
+++ b/Source/Engine/PackageBuilder/PackageBuilderOptions.cs
@@ -17,6 +17,8 @@ namespace Nezaboodka.Nevod
 
         public bool SyntaxInformationBinding { get; set; }
 
+        public bool? IsFileSystemCaseSensitive { get; set; }
+
         public PackageBuilderOptions()
         {
             PatternReferencesInlined = true;
@@ -28,6 +30,7 @@ namespace Nezaboodka.Nevod
                 source = Default;
             PatternReferencesInlined = source.PatternReferencesInlined;
             SyntaxInformationBinding = source.SyntaxInformationBinding;
+            IsFileSystemCaseSensitive = source.IsFileSystemCaseSensitive;
         }
     }
 }


### PR DESCRIPTION
Make file system case sensitivity configurable using PackageBuilderOptions. Default value is determined based on operating system: file system is considered case-insensitive on Windows and macOS and case-sensitive on Linux.