### PR TITLE
Fix children not created for range before elements

### DIFF
--- a/Source/Engine.Tests/Syntax/SyntaxChildrenTests.cs
+++ b/Source/Engine.Tests/Syntax/SyntaxChildrenTests.cs
@@ -592,16 +592,35 @@ Pattern = Nested1 + Nested2 @where {
         [TestMethod]
         public void ParenthesizedExpressionChildren()
         {
-            string pattern = @"#Company = ?('Optionality' + Space)";
-            PackageSyntax package = ParsePatterns(pattern);
-            var optionalitySyntax = (OptionalitySyntax)((PatternSyntax)package.Patterns[0]).Body;
-            optionalitySyntax.CreateChildren(pattern);
-            ReadOnlyCollection<Syntax> children = optionalitySyntax.Children;
-            Assert.AreEqual(children.Count, 4);
-            TestTokenIdAndTextRange(pattern, children[0], TokenId.Question, "?");
-            TestTokenIdAndTextRange(pattern, children[1], TokenId.OpenParenthesis, "(");
-            Assert.AreEqual(optionalitySyntax.Body, children[2]);
-            TestTokenIdAndTextRange(pattern, children[3], TokenId.CloseParenthesis, ")");
+            void ParenthesizedExpressionInOptionality()
+            {
+                string pattern = @"#Company = ?('Optionality' + Space)";
+                PackageSyntax package = ParsePatterns(pattern);
+                var optionalitySyntax = (OptionalitySyntax)((PatternSyntax)package.Patterns[0]).Body;
+                optionalitySyntax.CreateChildren(pattern);
+                ReadOnlyCollection<Syntax> children = optionalitySyntax.Children;
+                Assert.AreEqual(children.Count, 4);
+                TestTokenIdAndTextRange(pattern, children[0], TokenId.Question, "?");
+                TestTokenIdAndTextRange(pattern, children[1], TokenId.OpenParenthesis, "(");
+                Assert.AreEqual(optionalitySyntax.Body, children[2]);
+                TestTokenIdAndTextRange(pattern, children[3], TokenId.CloseParenthesis, ")");
+            }
+            void ParenthesizedExpressionInSequence()
+            {
+                string pattern = @"Pattern = (Word) + Num;";
+                PackageSyntax package = ParsePatterns(pattern);
+                var sequenceSyntax = (SequenceSyntax)((PatternSyntax)package.Patterns[0]).Body;
+                sequenceSyntax.CreateChildren(pattern);
+                ReadOnlyCollection<Syntax> children = sequenceSyntax.Children;
+                Assert.AreEqual(children.Count, 5);
+                TestTokenIdAndTextRange(pattern, children[0], TokenId.OpenParenthesis, "(");
+                Assert.AreEqual(sequenceSyntax.Elements[0], children[1]);
+                TestTokenIdAndTextRange(pattern, children[2], TokenId.CloseParenthesis, ") ");
+                TestTokenIdAndTextRange(pattern, children[3], TokenId.Plus, "+ ");
+                Assert.AreEqual(sequenceSyntax.Elements[1], children[4]);
+            }
+            ParenthesizedExpressionInOptionality();
+            ParenthesizedExpressionInSequence();
         }
     }
 }

--- a/Source/Engine/Syntax/AnySpanSyntax.cs
+++ b/Source/Engine/Syntax/AnySpanSyntax.cs
@@ -25,6 +25,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Left != null)
                 {
+                    int rangeEnd = Left.TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.Add(Left);
                     rangeStart = Left.TextRange.End;
                 }

--- a/Source/Engine/Syntax/ConjunctionSyntax.cs
+++ b/Source/Engine/Syntax/ConjunctionSyntax.cs
@@ -25,6 +25,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Elements.Count != 0)
                 {
+                    int rangeEnd = Elements[0].TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.AddForElements(Elements);
                     rangeStart = Elements[Elements.Count - 1].TextRange.End;
                 }

--- a/Source/Engine/Syntax/HavingSyntax.cs
+++ b/Source/Engine/Syntax/HavingSyntax.cs
@@ -22,6 +22,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Outer != null)
                 {
+                    int rangeEnd = Outer.TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.Add(Outer);
                     rangeStart = Outer.TextRange.End;
                 }

--- a/Source/Engine/Syntax/InsideSyntax.cs
+++ b/Source/Engine/Syntax/InsideSyntax.cs
@@ -22,6 +22,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Inner != null)
                 {
+                    int rangeEnd = Inner.TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.Add(Inner);
                     rangeStart = Inner.TextRange.End;
                 }

--- a/Source/Engine/Syntax/OutsideSyntax.cs
+++ b/Source/Engine/Syntax/OutsideSyntax.cs
@@ -22,6 +22,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Body != null)
                 {
+                    int rangeEnd = Body.TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.Add(Body);
                     rangeStart = Body.TextRange.End;
                 }

--- a/Source/Engine/Syntax/SequenceSyntax.cs
+++ b/Source/Engine/Syntax/SequenceSyntax.cs
@@ -25,6 +25,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Elements.Count != 0)
                 {
+                    int rangeEnd = Elements[0].TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.AddForElements(Elements);
                     rangeStart = Elements[Elements.Count - 1].TextRange.End;
                 }

--- a/Source/Engine/Syntax/WordSequenceSyntax.cs
+++ b/Source/Engine/Syntax/WordSequenceSyntax.cs
@@ -25,6 +25,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Elements.Count != 0)
                 {
+                    int rangeEnd = Elements[0].TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.AddForElements(Elements);
                     rangeStart = Elements[Elements.Count - 1].TextRange.End;
                 }

--- a/Source/Engine/Syntax/WordSpanSyntax.cs
+++ b/Source/Engine/Syntax/WordSpanSyntax.cs
@@ -27,6 +27,8 @@ namespace Nezaboodka.Nevod
                 int rangeStart = TextRange.Start;
                 if (Left != null)
                 {
+                    int rangeEnd = Left.TextRange.Start;
+                    childrenBuilder.AddInsideRange(rangeStart, rangeEnd);
                     childrenBuilder.Add(Left);
                     rangeStart = Left.TextRange.End;
                 }


### PR DESCRIPTION
For some syntaxes, range before first element was not scanned for children, which resulted in incorrect creation of the children list. For example, CreateChildren for sequence `(Word) + Num` created the following list: TokenSyntax, CloseParenthesis, Plus, TokenSyntax. This list misses OpenParenthesis in the beginning.